### PR TITLE
Feature/n3762

### DIFF
--- a/doc/html/string_ref.html
+++ b/doc/html/string_ref.html
@@ -3,7 +3,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=US-ASCII">
 <title>String_Ref</title>
 <link rel="stylesheet" href="../../../../doc/src/boostbook.css" type="text/css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.78.1">
+<meta name="generator" content="DocBook XSL Stylesheets V1.76.1">
 <link rel="home" href="string_ref.html" title="String_Ref">
 </head>
 <body bgcolor="white" text="black" link="#0000FF" vlink="#840084" alink="#0000FF">
@@ -22,10 +22,15 @@
 <div>
 <div><h2 class="title">
 <a name="string_ref"></a>String_Ref</h2></div>
-<div><div class="authorgroup"><div class="author"><h3 class="author">
+<div><div class="authorgroup">
+<div class="author"><h3 class="author">
 <span class="firstname">Marshall</span> <span class="surname">Clow</span>
-</h3></div></div></div>
-<div><p class="copyright">Copyright &#169; 2012 Marshall Clow</p></div>
+</h3></div>
+<div class="author"><h3 class="author">
+<span class="firstname">Peter A.</span> <span class="surname">Bigot</span>
+</h3></div>
+</div></div>
+<div><p class="copyright">Copyright &#169; 2012, 2013 Marshall Clow, Peter A. Bigot</p></div>
 <div><div class="legalnotice">
 <a name="string_ref.legal"></a><p>
         Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -37,10 +42,12 @@
 </div>
 <div class="toc">
 <p><b>Table of Contents</b></p>
-<dl class="toc">
+<dl>
 <dt><span class="section"><a href="string_ref.html#string_ref.overview">Overview</a></span></dt>
 <dt><span class="section"><a href="string_ref.html#string_ref.examples">Examples</a></span></dt>
 <dt><span class="section"><a href="string_ref.html#string_ref.reference">Reference </a></span></dt>
+<dt><span class="section"><a href="string_ref.html#string_ref.conformance_to_proposed_standard">Conformance
+    to Proposed Standard</a></span></dt>
 <dt><span class="section"><a href="string_ref.html#string_ref.history">History</a></span></dt>
 </dl>
 </div>
@@ -50,7 +57,9 @@
 </h2></div></div></div>
 <p>
       Boost.StringRef is an implementation of Jeffrey Yaskin's <a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3442.html" target="_top">N3442:
-      string_ref: a non-owning reference to a string</a>.
+      string_ref: a non-owning reference to a string</a>, updated with some changes
+      in <a href="http://isocpp.org/files/papers/N3762.html" target="_top">N3762: string_view:
+      a non-owning reference to a string, revision 5</a>.
     </p>
 <p>
       When you are parsing/processing strings from some external source, frequently
@@ -180,15 +189,26 @@
       <code class="computeroutput"><span class="preprocessor">#include</span> <span class="special">&lt;</span><span class="identifier">boost</span><span class="special">/</span><span class="identifier">utility</span><span class="special">/</span><span class="identifier">string_ref</span><span class="special">.</span><span class="identifier">hpp</span><span class="special">&gt;</span></code>
     </p>
 <p>
+      Type aliases:
+    </p>
+<pre class="programlisting"><span class="keyword">typedef</span> <span class="identifier">traits</span> <span class="identifier">traits_type</span><span class="special">;</span>
+<span class="keyword">typedef</span> <span class="identifier">charT</span> <span class="identifier">value_type</span><span class="special">;</span>
+<span class="keyword">typedef</span> <span class="keyword">const</span> <span class="identifier">charT</span><span class="special">*</span> <span class="identifier">pointer</span><span class="special">;</span>
+<span class="keyword">typedef</span> <span class="keyword">const</span> <span class="identifier">charT</span><span class="special">*</span> <span class="identifier">const_pointer</span><span class="special">;</span>
+<span class="keyword">typedef</span> <span class="keyword">const</span> <span class="identifier">charT</span><span class="special">&amp;</span> <span class="identifier">reference</span><span class="special">;</span>
+<span class="keyword">typedef</span> <span class="keyword">const</span> <span class="identifier">charT</span><span class="special">&amp;</span> <span class="identifier">const_reference</span><span class="special">;</span>
+<span class="keyword">typedef</span> <span class="identifier">pointer</span> <span class="identifier">const_iterator</span><span class="special">;</span> <span class="comment">// impl-defined</span>
+</pre>
+<p>
       Construction and copying:
     </p>
-<pre class="programlisting"><span class="identifier">BOOST_CONSTEXPR</span> <span class="identifier">basic_string_ref</span> <span class="special">();</span>    <span class="comment">// Constructs an empty string_ref</span>
+<pre class="programlisting"><span class="identifier">BOOST_CONSTEXPR</span> <span class="identifier">basic_string_ref</span> <span class="special">()</span> <span class="identifier">BOOST_NOEXCEPT</span><span class="special">;</span>    <span class="comment">// Constructs an empty string_ref</span>
 <span class="identifier">BOOST_CONSTEXPR</span> <span class="identifier">basic_string_ref</span><span class="special">(</span><span class="keyword">const</span> <span class="identifier">charT</span><span class="special">*</span> <span class="identifier">str</span><span class="special">);</span> <span class="comment">// Constructs from a NULL-terminated string</span>
 <span class="identifier">BOOST_CONSTEXPR</span> <span class="identifier">basic_string_ref</span><span class="special">(</span><span class="keyword">const</span> <span class="identifier">charT</span><span class="special">*</span> <span class="identifier">str</span><span class="special">,</span> <span class="identifier">size_type</span> <span class="identifier">len</span><span class="special">);</span> <span class="comment">// Constructs from a pointer, length pair</span>
 <span class="keyword">template</span><span class="special">&lt;</span><span class="keyword">typename</span> <span class="identifier">Allocator</span><span class="special">&gt;</span>
-<span class="identifier">basic_string_ref</span><span class="special">(</span><span class="keyword">const</span> <span class="identifier">std</span><span class="special">::</span><span class="identifier">basic_string</span><span class="special">&lt;</span><span class="identifier">charT</span><span class="special">,</span> <span class="identifier">traits</span><span class="special">,</span> <span class="identifier">Allocator</span><span class="special">&gt;&amp;</span> <span class="identifier">str</span><span class="special">);</span> <span class="comment">// Constructs from a std::string</span>
-<span class="identifier">basic_string_ref</span> <span class="special">(</span><span class="keyword">const</span> <span class="identifier">basic_string_ref</span> <span class="special">&amp;</span><span class="identifier">rhs</span><span class="special">);</span>
-<span class="identifier">basic_string_ref</span><span class="special">&amp;</span> <span class="keyword">operator</span><span class="special">=(</span><span class="keyword">const</span> <span class="identifier">basic_string_ref</span> <span class="special">&amp;</span><span class="identifier">rhs</span><span class="special">);</span>
+<span class="identifier">basic_string_ref</span><span class="special">(</span><span class="keyword">const</span> <span class="identifier">std</span><span class="special">::</span><span class="identifier">basic_string</span><span class="special">&lt;</span><span class="identifier">charT</span><span class="special">,</span> <span class="identifier">traits</span><span class="special">,</span> <span class="identifier">Allocator</span><span class="special">&gt;&amp;</span> <span class="identifier">str</span><span class="special">)</span> <span class="identifier">BOOST_NOEXCEPT</span><span class="special">;</span> <span class="comment">// Constructs from a std::string</span>
+<span class="identifier">basic_string_ref</span> <span class="special">(</span><span class="keyword">const</span> <span class="identifier">basic_string_ref</span> <span class="special">&amp;</span><span class="identifier">rhs</span><span class="special">)</span> <span class="identifier">BOOST_NOEXCEPT</span><span class="special">;</span>
+<span class="identifier">basic_string_ref</span><span class="special">&amp;</span> <span class="keyword">operator</span><span class="special">=(</span><span class="keyword">const</span> <span class="identifier">basic_string_ref</span> <span class="special">&amp;</span><span class="identifier">rhs</span><span class="special">)</span> <span class="identifier">BOOST_NOEXCEPT</span><span class="special">;</span>
 </pre>
 <p>
       <code class="computeroutput"><span class="identifier">string_ref</span></code> does not define
@@ -197,20 +217,20 @@
 <p>
       Basic container-like functions:
     </p>
-<pre class="programlisting"><span class="identifier">BOOST_CONSTEXPR</span> <span class="identifier">size_type</span> <span class="identifier">size</span><span class="special">()</span>     <span class="keyword">const</span> <span class="special">;</span>
-<span class="identifier">BOOST_CONSTEXPR</span> <span class="identifier">size_type</span> <span class="identifier">length</span><span class="special">()</span>   <span class="keyword">const</span> <span class="special">;</span>
-<span class="identifier">BOOST_CONSTEXPR</span> <span class="identifier">size_type</span> <span class="identifier">max_size</span><span class="special">()</span> <span class="keyword">const</span> <span class="special">;</span>
-<span class="identifier">BOOST_CONSTEXPR</span> <span class="keyword">bool</span> <span class="identifier">empty</span><span class="special">()</span>         <span class="keyword">const</span> <span class="special">;</span>
+<pre class="programlisting"><span class="identifier">BOOST_CONSTEXPR</span> <span class="identifier">size_type</span> <span class="identifier">size</span><span class="special">()</span>     <span class="keyword">const</span> <span class="identifier">BOOST_NOEXCEPT</span> <span class="special">;</span>
+<span class="identifier">BOOST_CONSTEXPR</span> <span class="identifier">size_type</span> <span class="identifier">length</span><span class="special">()</span>   <span class="keyword">const</span> <span class="identifier">BOOST_NOEXCEPT</span> <span class="special">;</span>
+<span class="identifier">BOOST_CONSTEXPR</span> <span class="identifier">size_type</span> <span class="identifier">max_size</span><span class="special">()</span> <span class="keyword">const</span> <span class="identifier">BOOST_NOEXCEPT</span> <span class="special">;</span>
+<span class="identifier">BOOST_CONSTEXPR</span> <span class="keyword">bool</span> <span class="identifier">empty</span><span class="special">()</span>         <span class="keyword">const</span> <span class="identifier">BOOST_NOEXCEPT</span> <span class="special">;</span>
 
 <span class="comment">// All iterators are const_iterators</span>
-<span class="identifier">BOOST_CONSTEXPR</span> <span class="identifier">const_iterator</span>  <span class="identifier">begin</span><span class="special">()</span> <span class="keyword">const</span> <span class="special">;</span>
-<span class="identifier">BOOST_CONSTEXPR</span> <span class="identifier">const_iterator</span> <span class="identifier">cbegin</span><span class="special">()</span> <span class="keyword">const</span> <span class="special">;</span>
-<span class="identifier">BOOST_CONSTEXPR</span> <span class="identifier">const_iterator</span>    <span class="identifier">end</span><span class="special">()</span> <span class="keyword">const</span> <span class="special">;</span>
-<span class="identifier">BOOST_CONSTEXPR</span> <span class="identifier">const_iterator</span>   <span class="identifier">cend</span><span class="special">()</span> <span class="keyword">const</span> <span class="special">;</span>
-<span class="identifier">const_reverse_iterator</span>         <span class="identifier">rbegin</span><span class="special">()</span> <span class="keyword">const</span> <span class="special">;</span>
-<span class="identifier">const_reverse_iterator</span>        <span class="identifier">crbegin</span><span class="special">()</span> <span class="keyword">const</span> <span class="special">;</span>
-<span class="identifier">const_reverse_iterator</span>           <span class="identifier">rend</span><span class="special">()</span> <span class="keyword">const</span> <span class="special">;</span>
-<span class="identifier">const_reverse_iterator</span>          <span class="identifier">crend</span><span class="special">()</span> <span class="keyword">const</span> <span class="special">;</span>
+<span class="identifier">BOOST_CONSTEXPR</span> <span class="identifier">const_iterator</span>  <span class="identifier">begin</span><span class="special">()</span> <span class="keyword">const</span> <span class="identifier">BOOST_NOEXCEPT</span> <span class="special">;</span>
+<span class="identifier">BOOST_CONSTEXPR</span> <span class="identifier">const_iterator</span> <span class="identifier">cbegin</span><span class="special">()</span> <span class="keyword">const</span> <span class="identifier">BOOST_NOEXCEPT</span> <span class="special">;</span>
+<span class="identifier">BOOST_CONSTEXPR</span> <span class="identifier">const_iterator</span>    <span class="identifier">end</span><span class="special">()</span> <span class="keyword">const</span> <span class="identifier">BOOST_NOEXCEPT</span> <span class="special">;</span>
+<span class="identifier">BOOST_CONSTEXPR</span> <span class="identifier">const_iterator</span>   <span class="identifier">cend</span><span class="special">()</span> <span class="keyword">const</span> <span class="identifier">BOOST_NOEXCEPT</span> <span class="special">;</span>
+<span class="identifier">const_reverse_iterator</span>         <span class="identifier">rbegin</span><span class="special">()</span> <span class="keyword">const</span> <span class="identifier">BOOST_NOEXCEPT</span> <span class="special">;</span>
+<span class="identifier">const_reverse_iterator</span>        <span class="identifier">crbegin</span><span class="special">()</span> <span class="keyword">const</span> <span class="identifier">BOOST_NOEXCEPT</span> <span class="special">;</span>
+<span class="identifier">const_reverse_iterator</span>           <span class="identifier">rend</span><span class="special">()</span> <span class="keyword">const</span> <span class="identifier">BOOST_NOEXCEPT</span> <span class="special">;</span>
+<span class="identifier">const_reverse_iterator</span>          <span class="identifier">crend</span><span class="special">()</span> <span class="keyword">const</span> <span class="identifier">BOOST_NOEXCEPT</span> <span class="special">;</span>
 </pre>
 <p>
       Access to the individual elements (all of which are const):
@@ -219,42 +239,106 @@
 <span class="keyword">const</span> <span class="identifier">charT</span><span class="special">&amp;</span> <span class="identifier">at</span><span class="special">(</span><span class="identifier">size_t</span> <span class="identifier">pos</span><span class="special">)</span> <span class="keyword">const</span> <span class="special">;</span>
 <span class="identifier">BOOST_CONSTEXPR</span> <span class="keyword">const</span> <span class="identifier">charT</span><span class="special">&amp;</span> <span class="identifier">front</span><span class="special">()</span> <span class="keyword">const</span> <span class="special">;</span>
 <span class="identifier">BOOST_CONSTEXPR</span> <span class="keyword">const</span> <span class="identifier">charT</span><span class="special">&amp;</span> <span class="identifier">back</span><span class="special">()</span>  <span class="keyword">const</span> <span class="special">;</span>
-<span class="identifier">BOOST_CONSTEXPR</span> <span class="keyword">const</span> <span class="identifier">charT</span><span class="special">*</span> <span class="identifier">data</span><span class="special">()</span>  <span class="keyword">const</span> <span class="special">;</span>
+<span class="identifier">BOOST_CONSTEXPR</span> <span class="keyword">const</span> <span class="identifier">charT</span><span class="special">*</span> <span class="identifier">data</span><span class="special">()</span>  <span class="keyword">const</span> <span class="identifier">BOOST_NOEXCEPT</span> <span class="special">;</span>
 </pre>
 <p>
       Modifying the <code class="computeroutput"><span class="identifier">string_ref</span></code> (but
       not the underlying data):
     </p>
-<pre class="programlisting"><span class="keyword">void</span> <span class="identifier">clear</span><span class="special">();</span>
+<pre class="programlisting"><span class="keyword">void</span> <span class="identifier">clear</span><span class="special">()</span> <span class="identifier">BOOST_NOEXCEPT</span><span class="special">;</span>
 <span class="keyword">void</span> <span class="identifier">remove_prefix</span><span class="special">(</span><span class="identifier">size_type</span> <span class="identifier">n</span><span class="special">);</span>
 <span class="keyword">void</span> <span class="identifier">remove_suffix</span><span class="special">(</span><span class="identifier">size_type</span> <span class="identifier">n</span><span class="special">);</span>
+<span class="keyword">void</span> <span class="identifier">swap</span><span class="special">(</span><span class="identifier">basic_string_ref</span><span class="special">&amp;</span> <span class="identifier">s</span><span class="special">)</span> <span class="identifier">BOOST_NOEXCEPT</span><span class="special">;</span>
 </pre>
 <p>
       Searching:
     </p>
-<pre class="programlisting"><span class="identifier">size_type</span> <span class="identifier">find</span><span class="special">(</span><span class="identifier">basic_string_ref</span> <span class="identifier">s</span><span class="special">)</span> <span class="keyword">const</span> <span class="special">;</span>
-<span class="identifier">size_type</span> <span class="identifier">find</span><span class="special">(</span><span class="identifier">charT</span> <span class="identifier">c</span><span class="special">)</span> <span class="keyword">const</span> <span class="special">;</span>
-<span class="identifier">size_type</span> <span class="identifier">rfind</span><span class="special">(</span><span class="identifier">basic_string_ref</span> <span class="identifier">s</span><span class="special">)</span> <span class="keyword">const</span> <span class="special">;</span>
-<span class="identifier">size_type</span> <span class="identifier">rfind</span><span class="special">(</span><span class="identifier">charT</span> <span class="identifier">c</span><span class="special">)</span> <span class="keyword">const</span> <span class="special">;</span>
-<span class="identifier">size_type</span> <span class="identifier">find_first_of</span><span class="special">(</span><span class="identifier">charT</span> <span class="identifier">c</span><span class="special">)</span> <span class="keyword">const</span> <span class="special">;</span>
-<span class="identifier">size_type</span> <span class="identifier">find_last_of</span> <span class="special">(</span><span class="identifier">charT</span> <span class="identifier">c</span><span class="special">)</span> <span class="keyword">const</span> <span class="special">;</span>
+<pre class="programlisting"><span class="identifier">size_type</span> <span class="identifier">find</span><span class="special">(</span><span class="identifier">basic_string_ref</span> <span class="identifier">s</span><span class="special">,</span> <span class="identifier">size_type</span> <span class="identifier">pos</span><span class="special">=</span><span class="number">0</span><span class="special">)</span> <span class="keyword">const</span> <span class="identifier">BOOST_NOEXCEPT</span> <span class="special">;</span>
+<span class="identifier">size_type</span> <span class="identifier">find</span><span class="special">(</span><span class="identifier">charT</span> <span class="identifier">c</span><span class="special">,</span> <span class="identifier">size_type</span> <span class="identifier">pos</span><span class="special">=</span><span class="number">0</span><span class="special">)</span> <span class="keyword">const</span> <span class="identifier">BOOST_NOEXCEPT</span> <span class="special">;</span>
+<span class="identifier">size_type</span> <span class="identifier">rfind</span><span class="special">(</span><span class="identifier">basic_string_ref</span> <span class="identifier">s</span><span class="special">,</span> <span class="identifier">size_type</span> <span class="identifier">pos</span><span class="special">=</span><span class="identifier">npos</span><span class="special">)</span> <span class="keyword">const</span> <span class="identifier">BOOST_NOEXCEPT</span> <span class="special">;</span>
+<span class="identifier">size_type</span> <span class="identifier">rfind</span><span class="special">(</span><span class="identifier">charT</span> <span class="identifier">c</span><span class="special">,</span> <span class="identifier">size_type</span> <span class="identifier">pos</span><span class="special">=</span><span class="identifier">npos</span><span class="special">)</span> <span class="keyword">const</span> <span class="identifier">BOOST_NOEXCEPT</span> <span class="special">;</span>
+<span class="identifier">size_type</span> <span class="identifier">find_first_of</span><span class="special">(</span><span class="identifier">charT</span> <span class="identifier">c</span><span class="special">,</span> <span class="identifier">size_type</span> <span class="identifier">pos</span><span class="special">=</span><span class="number">0</span><span class="special">)</span> <span class="keyword">const</span> <span class="identifier">BOOST_NOEXCEPT</span> <span class="special">;</span>
+<span class="identifier">size_type</span> <span class="identifier">find_last_of</span> <span class="special">(</span><span class="identifier">charT</span> <span class="identifier">c</span><span class="special">,</span> <span class="identifier">size_type</span> <span class="identifier">pos</span><span class="special">=</span><span class="identifier">npos</span><span class="special">)</span> <span class="keyword">const</span> <span class="identifier">BOOST_NOEXCEPT</span> <span class="special">;</span>
 
-<span class="identifier">size_type</span> <span class="identifier">find_first_of</span><span class="special">(</span><span class="identifier">basic_string_ref</span> <span class="identifier">s</span><span class="special">)</span> <span class="keyword">const</span> <span class="special">;</span>
-<span class="identifier">size_type</span> <span class="identifier">find_last_of</span><span class="special">(</span><span class="identifier">basic_string_ref</span> <span class="identifier">s</span><span class="special">)</span> <span class="keyword">const</span> <span class="special">;</span>
-<span class="identifier">size_type</span> <span class="identifier">find_first_not_of</span><span class="special">(</span><span class="identifier">basic_string_ref</span> <span class="identifier">s</span><span class="special">)</span> <span class="keyword">const</span> <span class="special">;</span>
-<span class="identifier">size_type</span> <span class="identifier">find_first_not_of</span><span class="special">(</span><span class="identifier">charT</span> <span class="identifier">c</span><span class="special">)</span> <span class="keyword">const</span> <span class="special">;</span>
-<span class="identifier">size_type</span> <span class="identifier">find_last_not_of</span><span class="special">(</span><span class="identifier">basic_string_ref</span> <span class="identifier">s</span><span class="special">)</span> <span class="keyword">const</span> <span class="special">;</span>
-<span class="identifier">size_type</span> <span class="identifier">find_last_not_of</span><span class="special">(</span><span class="identifier">charT</span> <span class="identifier">c</span><span class="special">)</span> <span class="keyword">const</span> <span class="special">;</span>
+<span class="identifier">size_type</span> <span class="identifier">find_first_of</span><span class="special">(</span><span class="identifier">basic_string_ref</span> <span class="identifier">s</span><span class="special">,</span> <span class="identifier">size_type</span> <span class="identifier">pos</span><span class="special">=</span><span class="number">0</span><span class="special">)</span> <span class="keyword">const</span> <span class="identifier">BOOST_NOEXCEPT</span> <span class="special">;</span>
+<span class="identifier">size_type</span> <span class="identifier">find_last_of</span><span class="special">(</span><span class="identifier">basic_string_ref</span> <span class="identifier">s</span><span class="special">,</span> <span class="identifier">size_type</span> <span class="identifier">pos</span><span class="special">=</span><span class="identifier">npos</span><span class="special">)</span> <span class="keyword">const</span> <span class="identifier">BOOST_NOEXCEPT</span> <span class="special">;</span>
+<span class="identifier">size_type</span> <span class="identifier">find_first_not_of</span><span class="special">(</span><span class="identifier">basic_string_ref</span> <span class="identifier">s</span><span class="special">,</span> <span class="identifier">size_type</span> <span class="identifier">pos</span><span class="special">=</span><span class="number">0</span><span class="special">)</span> <span class="keyword">const</span> <span class="identifier">BOOST_NOEXCEPT</span> <span class="special">;</span>
+<span class="identifier">size_type</span> <span class="identifier">find_first_not_of</span><span class="special">(</span><span class="identifier">charT</span> <span class="identifier">c</span><span class="special">,</span> <span class="identifier">size_type</span> <span class="identifier">pos</span><span class="special">=</span><span class="number">0</span><span class="special">)</span> <span class="keyword">const</span> <span class="identifier">BOOST_NOEXCEPT</span> <span class="special">;</span>
+<span class="identifier">size_type</span> <span class="identifier">find_last_not_of</span><span class="special">(</span><span class="identifier">basic_string_ref</span> <span class="identifier">s</span><span class="special">,</span> <span class="identifier">size_type</span> <span class="identifier">pos</span><span class="special">=</span><span class="identifier">npos</span><span class="special">)</span> <span class="keyword">const</span> <span class="identifier">BOOST_NOEXCEPT</span> <span class="special">;</span>
+<span class="identifier">size_type</span> <span class="identifier">find_last_not_of</span><span class="special">(</span><span class="identifier">charT</span> <span class="identifier">c</span><span class="special">,</span> <span class="identifier">size_type</span> <span class="identifier">pos</span><span class="special">=</span><span class="identifier">npos</span><span class="special">)</span> <span class="keyword">const</span> <span class="identifier">BOOST_NOEXCEPT</span> <span class="special">;</span>
 </pre>
 <p>
       String-like operations:
     </p>
-<pre class="programlisting"><span class="identifier">BOOST_CONSTEXPR</span> <span class="identifier">basic_string_ref</span> <span class="identifier">substr</span><span class="special">(</span><span class="identifier">size_type</span> <span class="identifier">pos</span><span class="special">,</span> <span class="identifier">size_type</span> <span class="identifier">n</span><span class="special">=</span><span class="identifier">npos</span><span class="special">)</span> <span class="keyword">const</span> <span class="special">;</span> <span class="comment">// Creates a new string_ref</span>
+<pre class="programlisting"><span class="identifier">BOOST_CONSTEXPR</span> <span class="identifier">basic_string_ref</span> <span class="identifier">substr</span><span class="special">(</span><span class="identifier">size_type</span> <span class="identifier">pos</span><span class="special">=</span><span class="identifier">npos</span><span class="special">,</span> <span class="identifier">size_type</span> <span class="identifier">n</span><span class="special">=</span><span class="identifier">npos</span><span class="special">)</span> <span class="keyword">const</span> <span class="special">;</span> <span class="comment">// Creates a new string_ref</span>
+<span class="keyword">int</span> <span class="identifier">compare</span><span class="special">(</span><span class="identifier">basic_string_ref</span> <span class="identifier">x</span><span class="special">)</span> <span class="keyword">const</span> <span class="identifier">BOOST_NOEXCEPT</span> <span class="special">;</span> <span class="comment">// like std::string::compare</span>
+<span class="keyword">int</span> <span class="identifier">compare</span><span class="special">(</span><span class="identifier">size_type</span> <span class="identifier">pos1</span><span class="special">,</span> <span class="identifier">size_type</span> <span class="identifier">n1</span><span class="special">,</span> <span class="identifier">basic_string_ref</span> <span class="identifier">str</span><span class="special">)</span> <span class="keyword">const</span> <span class="special">;</span>
+<span class="keyword">int</span> <span class="identifier">compare</span><span class="special">(</span><span class="identifier">size_type</span> <span class="identifier">pos1</span><span class="special">,</span> <span class="identifier">size_type</span> <span class="identifier">n1</span><span class="special">,</span> <span class="identifier">basic_string_ref</span> <span class="identifier">str</span><span class="special">,</span>
+            <span class="identifier">size_type</span> <span class="identifier">pos2</span><span class="special">,</span> <span class="identifier">size_type</span> <span class="identifier">n2</span><span class="special">)</span> <span class="keyword">const</span> <span class="special">;</span>
+<span class="keyword">int</span> <span class="identifier">compare</span><span class="special">(</span><span class="keyword">const</span> <span class="identifier">charT</span><span class="special">*</span> <span class="identifier">s</span><span class="special">)</span> <span class="keyword">const</span> <span class="special">;</span>
+<span class="keyword">int</span> <span class="identifier">compare</span><span class="special">(</span><span class="identifier">size_type</span> <span class="identifier">pos1</span><span class="special">,</span> <span class="identifier">size_type</span> <span class="identifier">n1</span><span class="special">,</span> <span class="keyword">const</span> <span class="identifier">charT</span><span class="special">*</span> <span class="identifier">s</span><span class="special">)</span> <span class="keyword">const</span> <span class="special">;</span>
+<span class="keyword">int</span> <span class="identifier">compare</span><span class="special">(</span><span class="identifier">size_type</span> <span class="identifier">pos1</span><span class="special">,</span> <span class="identifier">size_type</span> <span class="identifier">n1</span><span class="special">,</span> <span class="keyword">const</span> <span class="identifier">charT</span><span class="special">*</span> <span class="identifier">s</span><span class="special">,</span> <span class="identifier">size_type</span> <span class="identifier">n2</span><span class="special">)</span> <span class="keyword">const</span> <span class="special">;</span>
+<span class="identifier">size_type</span> <span class="identifier">copy</span><span class="special">(</span><span class="identifier">charT</span><span class="special">*</span> <span class="identifier">s</span><span class="special">,</span> <span class="identifier">size_type</span> <span class="identifier">n</span><span class="special">,</span> <span class="identifier">size_type</span> <span class="identifier">pos</span><span class="special">=</span><span class="number">0</span><span class="special">)</span> <span class="keyword">const</span> <span class="special">;</span> <span class="comment">// like std::copy_n</span>
+<span class="comment">// The following methods were removed from proposal in N3685</span>
 <span class="keyword">bool</span> <span class="identifier">starts_with</span><span class="special">(</span><span class="identifier">charT</span> <span class="identifier">c</span><span class="special">)</span> <span class="keyword">const</span> <span class="special">;</span>
 <span class="keyword">bool</span> <span class="identifier">starts_with</span><span class="special">(</span><span class="identifier">basic_string_ref</span> <span class="identifier">x</span><span class="special">)</span> <span class="keyword">const</span> <span class="special">;</span>
 <span class="keyword">bool</span> <span class="identifier">ends_with</span><span class="special">(</span><span class="identifier">charT</span> <span class="identifier">c</span><span class="special">)</span> <span class="keyword">const</span> <span class="special">;</span>
 <span class="keyword">bool</span> <span class="identifier">ends_with</span><span class="special">(</span><span class="identifier">basic_string_ref</span> <span class="identifier">x</span><span class="special">)</span> <span class="keyword">const</span> <span class="special">;</span>
 </pre>
+<p>
+      Note that <code class="computeroutput"><span class="identifier">starts_with</span></code> and
+      <code class="computeroutput"><span class="identifier">ends_with</span></code> were removed from
+      the proposed interface in N3685 but are currently retained in Boost.
+    </p>
+</div>
+<div class="section">
+<div class="titlepage"><div><div><h2 class="title" style="clear: both">
+<a name="string_ref.conformance_to_proposed_standard"></a><a class="link" href="string_ref.html#string_ref.conformance_to_proposed_standard" title="Conformance to Proposed Standard">Conformance
+    to Proposed Standard</a>
+</h2></div></div></div>
+<p>
+      Boost.StringRef differs from <a href="http://isocpp.org/files/papers/N3762.html" target="_top">N3762:
+      string_view: a non-owning reference to a string, revision 5</a> in the
+      following particulars:
+    </p>
+<div class="orderedlist"><ol class="orderedlist" type="1">
+<li class="listitem">
+          The proposed template name changed from <code class="computeroutput"><span class="identifier">string_ref</span></code>
+          to <code class="computeroutput"><span class="identifier">string_view</span></code> at <a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3609.html" target="_top">N3609</a>.
+          At this time the new name is not supported.
+        </li>
+<li class="listitem">
+          Using the default constructor <code class="computeroutput"><span class="identifier">string_ref</span><span class="special">()</span></code> produces an object that returns a null
+          pointer from <code class="computeroutput"><span class="identifier">data</span><span class="special">()</span></code>.
+          N3762 requires that <code class="computeroutput"><span class="identifier">data</span><span class="special">()</span></code> never return a null pointer.
+        </li>
+<li class="listitem">
+          Boost's implementation adds the following non-standard member functions:
+          <div class="orderedlist"><ol class="orderedlist" type="a">
+<li class="listitem">
+                <code class="computeroutput"><span class="identifier">to_string</span></code>
+              </li>
+<li class="listitem">
+                <code class="computeroutput"><span class="identifier">starts_with</span></code> (removed
+                in <a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3685.html" target="_top">N3685</a>)
+              </li>
+<li class="listitem">
+                <code class="computeroutput"><span class="identifier">ends_with</span></code> (removed
+                in <a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3685.html" target="_top">N3685</a>)
+              </li>
+</ol></div>
+        </li>
+<li class="listitem">
+          <a href="http://isocpp.org/files/papers/N3762.html#string.view.nonmem" target="_top">non-member
+          <code class="computeroutput"><span class="identifier">to_string</span></code></a> is not
+          provided.
+        </li>
+<li class="listitem">
+          <code class="computeroutput"><span class="keyword">const</span> <span class="identifier">charT</span><span class="special">*</span></code> overloads for member functions in <a href="http://isocpp.org/files/papers/N3762.html#h5o-6" target="_top">string.view.find</a>
+          that are not documented are not provided. The <code class="computeroutput"><span class="identifier">charT</span></code>
+          overloads are provided.
+        </li>
+</ol></div>
 </div>
 <div class="section">
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
@@ -262,16 +346,24 @@
 </h2></div></div></div>
 <h4>
 <a name="string_ref.history.h0"></a>
-      <span class="phrase"><a name="string_ref.history.boost_1_53"></a></span><a class="link" href="string_ref.html#string_ref.history.boost_1_53">boost
+      <span><a name="string_ref.history.boost_1_53"></a></span><a class="link" href="string_ref.html#string_ref.history.boost_1_53">boost
       1.53</a>
     </h4>
-<div class="itemizedlist"><ul class="itemizedlist" style="list-style-type: disc; "><li class="listitem">
+<div class="itemizedlist"><ul class="itemizedlist" type="disc"><li class="listitem">
           Introduced
+        </li></ul></div>
+<h4>
+<a name="string_ref.history.h1"></a>
+      <span><a name="string_ref.history.boost_1_56"></a></span><a class="link" href="string_ref.html#string_ref.history.boost_1_56">boost
+      1.56</a>
+    </h4>
+<div class="itemizedlist"><ul class="itemizedlist" type="disc"><li class="listitem">
+          Updated with changes in N3762
         </li></ul></div>
 </div>
 </div>
 <table xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" width="100%"><tr>
-<td align="left"><p><small>Last revised: November 23, 2013 at 14:12:56 GMT</small></p></td>
+<td align="left"><p><small>Last revised: December 24, 2013 at 19:00:25 GMT</small></p></td>
 <td align="right"><div class="copyright-footer"></div></td>
 </tr></table>
 <hr>

--- a/doc/string_ref.qbk
+++ b/doc/string_ref.qbk
@@ -21,7 +21,7 @@
 [/===============]
 
 Boost.StringRef is an implementation of Jeffrey Yaskin's [@http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3442.html N3442:
-string_ref: a non-owning reference to a string]. 
+string_ref: a non-owning reference to a string], updated with some changes in [@http://isocpp.org/files/papers/N3762.html N3762: string_view: a non-owning reference to a string, revision 5].
 
 When you are parsing/processing strings from some external source, frequently you want to pass a piece of text to a procedure for specialized processing. The canonical way to do this is as a `std::string`, but that has certain drawbacks:
 
@@ -82,6 +82,16 @@ No memory allocations. No copying of character data. No changes to the code othe
 The header file "string_ref.hpp" defines a template `boost::basic_string_ref`, and four specializations - for `char` / `wchar_t` / `char16_t` / `char32_t` .
 
 `#include <boost/utility/string_ref.hpp>`
+
+Type aliases:
+
+    typedef traits traits_type;
+    typedef charT value_type;
+    typedef const charT* pointer;
+    typedef const charT* const_pointer;
+    typedef const charT& reference;
+    typedef const charT& const_reference;
+    typedef pointer const_iterator; // impl-defined
 
 Construction and copying:
 
@@ -145,10 +155,14 @@ Searching:
 String-like operations:
 
     BOOST_CONSTEXPR basic_string_ref substr(size_type pos, size_type n=npos) const ; // Creates a new string_ref
+    int compare(basic_string_ref x) const ; // like std::string::compare
+    // The following methods were removed from proposal in N3685
     bool starts_with(charT c) const ;
     bool starts_with(basic_string_ref x) const ;
     bool ends_with(charT c) const ;
     bool ends_with(basic_string_ref x) const ;
+
+Note that `starts_with` and `ends_with` were removed from the proposed interface in N3685 but are currently retained in Boost.
 
 [endsect]
 
@@ -158,10 +172,8 @@ String-like operations:
 
 [heading boost 1.53]
 * Introduced
-    
+
+[heading boost 1.56]
+* Updated with changes in N3762
 
 [endsect]
-
-
-
-

--- a/doc/string_ref.qbk
+++ b/doc/string_ref.qbk
@@ -96,7 +96,7 @@ Type aliases:
 Construction and copying:
 
     BOOST_CONSTEXPR basic_string_ref () BOOST_NOEXCEPT;    // Constructs an empty string_ref
-    BOOST_CONSTEXPR basic_string_ref(const charT* str); // Constructs from a NULL-terminated string
+    BOOST_CONSTEXPR basic_string_ref(const charT* str); // Constructs from a null-terminated string
     BOOST_CONSTEXPR basic_string_ref(const charT* str, size_type len); // Constructs from a pointer, length pair
     template<typename Allocator>
     basic_string_ref(const std::basic_string<charT, traits, Allocator>& str) BOOST_NOEXCEPT; // Constructs from a std::string
@@ -181,8 +181,6 @@ Note that `starts_with` and `ends_with` were removed from the proposed interface
 Boost.StringRef differs from [@http://isocpp.org/files/papers/N3762.html N3762: string_view: a non-owning reference to a string, revision 5] in the following particulars:
 
 # The proposed template name changed from `string_ref` to `string_view` at [@http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3609.html N3609].  At this time the new name is not supported.
-
-# Using the default constructor `string_ref()` produces an object that returns a null pointer from `data()`.  N3762 requires that `data()` never return a null pointer.
 
 # Boost's implementation adds the following non-standard member functions:
 

--- a/doc/string_ref.qbk
+++ b/doc/string_ref.qbk
@@ -138,23 +138,23 @@ Modifying the `string_ref` (but not the underlying data):
 
 Searching:
 
-    size_type find(basic_string_ref s) const BOOST_NOEXCEPT ;
-    size_type find(charT c) const BOOST_NOEXCEPT ;
-    size_type rfind(basic_string_ref s) const BOOST_NOEXCEPT ;
-    size_type rfind(charT c) const BOOST_NOEXCEPT ;
-    size_type find_first_of(charT c) const BOOST_NOEXCEPT ;
-    size_type find_last_of (charT c) const BOOST_NOEXCEPT ;
+    size_type find(basic_string_ref s, size_type pos=0) const BOOST_NOEXCEPT ;
+    size_type find(charT c, size_type pos=0) const BOOST_NOEXCEPT ;
+    size_type rfind(basic_string_ref s, size_type pos=npos) const BOOST_NOEXCEPT ;
+    size_type rfind(charT c, size_type pos=npos) const BOOST_NOEXCEPT ;
+    size_type find_first_of(charT c, size_type pos=0) const BOOST_NOEXCEPT ;
+    size_type find_last_of (charT c, size_type pos=npos) const BOOST_NOEXCEPT ;
         
-    size_type find_first_of(basic_string_ref s) const BOOST_NOEXCEPT ;
-    size_type find_last_of(basic_string_ref s) const BOOST_NOEXCEPT ;
-    size_type find_first_not_of(basic_string_ref s) const BOOST_NOEXCEPT ;
-    size_type find_first_not_of(charT c) const BOOST_NOEXCEPT ;
-    size_type find_last_not_of(basic_string_ref s) const BOOST_NOEXCEPT ;
-    size_type find_last_not_of(charT c) const BOOST_NOEXCEPT ;
+    size_type find_first_of(basic_string_ref s, size_type pos=0) const BOOST_NOEXCEPT ;
+    size_type find_last_of(basic_string_ref s, size_type pos=npos) const BOOST_NOEXCEPT ;
+    size_type find_first_not_of(basic_string_ref s, size_type pos=0) const BOOST_NOEXCEPT ;
+    size_type find_first_not_of(charT c, size_type pos=0) const BOOST_NOEXCEPT ;
+    size_type find_last_not_of(basic_string_ref s, size_type pos=npos) const BOOST_NOEXCEPT ;
+    size_type find_last_not_of(charT c, size_type pos=npos) const BOOST_NOEXCEPT ;
 
 String-like operations:
 
-    BOOST_CONSTEXPR basic_string_ref substr(size_type pos, size_type n=npos) const ; // Creates a new string_ref
+    BOOST_CONSTEXPR basic_string_ref substr(size_type pos=npos, size_type n=npos) const ; // Creates a new string_ref
     int compare(basic_string_ref x) const BOOST_NOEXCEPT ; // like std::string::compare
     size_type copy(charT* s, size_type n, size_type pos=0) const ; // like std::copy_n
     // The following methods were removed from proposal in N3685

--- a/doc/string_ref.qbk
+++ b/doc/string_ref.qbk
@@ -135,6 +135,7 @@ Modifying the `string_ref` (but not the underlying data):
     void clear() BOOST_NOEXCEPT;
     void remove_prefix(size_type n);
     void remove_suffix(size_type n);
+    void swap(basic_string_ref& s) BOOST_NOEXCEPT;
 
 Searching:
 

--- a/doc/string_ref.qbk
+++ b/doc/string_ref.qbk
@@ -156,6 +156,7 @@ String-like operations:
 
     BOOST_CONSTEXPR basic_string_ref substr(size_type pos, size_type n=npos) const ; // Creates a new string_ref
     int compare(basic_string_ref x) const BOOST_NOEXCEPT ; // like std::string::compare
+    size_type copy(charT* s, size_type n, size_type pos=0) const ; // like std::copy_n
     // The following methods were removed from proposal in N3685
     bool starts_with(charT c) const ;
     bool starts_with(basic_string_ref x) const ;

--- a/doc/string_ref.qbk
+++ b/doc/string_ref.qbk
@@ -95,32 +95,32 @@ Type aliases:
 
 Construction and copying:
 
-    BOOST_CONSTEXPR basic_string_ref ();    // Constructs an empty string_ref
+    BOOST_CONSTEXPR basic_string_ref () BOOST_NOEXCEPT;    // Constructs an empty string_ref
     BOOST_CONSTEXPR basic_string_ref(const charT* str); // Constructs from a NULL-terminated string
     BOOST_CONSTEXPR basic_string_ref(const charT* str, size_type len); // Constructs from a pointer, length pair
     template<typename Allocator>
-    basic_string_ref(const std::basic_string<charT, traits, Allocator>& str); // Constructs from a std::string
-    basic_string_ref (const basic_string_ref &rhs);
-    basic_string_ref& operator=(const basic_string_ref &rhs);
+    basic_string_ref(const std::basic_string<charT, traits, Allocator>& str) BOOST_NOEXCEPT; // Constructs from a std::string
+    basic_string_ref (const basic_string_ref &rhs) BOOST_NOEXCEPT;
+    basic_string_ref& operator=(const basic_string_ref &rhs) BOOST_NOEXCEPT;
 
 `string_ref` does not define a move constructor nor a move-assignment operator because copying a `string_ref` is just a cheap as moving one.
 
 Basic container-like functions:
 
-    BOOST_CONSTEXPR size_type size()     const ;
-    BOOST_CONSTEXPR size_type length()   const ;
-    BOOST_CONSTEXPR size_type max_size() const ;
-    BOOST_CONSTEXPR bool empty()         const ;
+    BOOST_CONSTEXPR size_type size()     const BOOST_NOEXCEPT ;
+    BOOST_CONSTEXPR size_type length()   const BOOST_NOEXCEPT ;
+    BOOST_CONSTEXPR size_type max_size() const BOOST_NOEXCEPT ;
+    BOOST_CONSTEXPR bool empty()         const BOOST_NOEXCEPT ;
     
     // All iterators are const_iterators
-    BOOST_CONSTEXPR const_iterator  begin() const ;
-    BOOST_CONSTEXPR const_iterator cbegin() const ;
-    BOOST_CONSTEXPR const_iterator    end() const ;
-    BOOST_CONSTEXPR const_iterator   cend() const ;
-    const_reverse_iterator         rbegin() const ;
-    const_reverse_iterator        crbegin() const ;
-    const_reverse_iterator           rend() const ;
-    const_reverse_iterator          crend() const ;
+    BOOST_CONSTEXPR const_iterator  begin() const BOOST_NOEXCEPT ;
+    BOOST_CONSTEXPR const_iterator cbegin() const BOOST_NOEXCEPT ;
+    BOOST_CONSTEXPR const_iterator    end() const BOOST_NOEXCEPT ;
+    BOOST_CONSTEXPR const_iterator   cend() const BOOST_NOEXCEPT ;
+    const_reverse_iterator         rbegin() const BOOST_NOEXCEPT ;
+    const_reverse_iterator        crbegin() const BOOST_NOEXCEPT ;
+    const_reverse_iterator           rend() const BOOST_NOEXCEPT ;
+    const_reverse_iterator          crend() const BOOST_NOEXCEPT ;
 
 Access to the individual elements (all of which are const):
 
@@ -128,34 +128,34 @@ Access to the individual elements (all of which are const):
     const charT& at(size_t pos) const ;
     BOOST_CONSTEXPR const charT& front() const ;
     BOOST_CONSTEXPR const charT& back()  const ;
-    BOOST_CONSTEXPR const charT* data()  const ;
+    BOOST_CONSTEXPR const charT* data()  const BOOST_NOEXCEPT ;
 
 Modifying the `string_ref` (but not the underlying data):
 
-    void clear();
+    void clear() BOOST_NOEXCEPT;
     void remove_prefix(size_type n);
     void remove_suffix(size_type n);
 
 Searching:
 
-    size_type find(basic_string_ref s) const ;
-    size_type find(charT c) const ;
-    size_type rfind(basic_string_ref s) const ;
-    size_type rfind(charT c) const ;
-    size_type find_first_of(charT c) const ;
-    size_type find_last_of (charT c) const ;
+    size_type find(basic_string_ref s) const BOOST_NOEXCEPT ;
+    size_type find(charT c) const BOOST_NOEXCEPT ;
+    size_type rfind(basic_string_ref s) const BOOST_NOEXCEPT ;
+    size_type rfind(charT c) const BOOST_NOEXCEPT ;
+    size_type find_first_of(charT c) const BOOST_NOEXCEPT ;
+    size_type find_last_of (charT c) const BOOST_NOEXCEPT ;
         
-    size_type find_first_of(basic_string_ref s) const ;
-    size_type find_last_of(basic_string_ref s) const ;
-    size_type find_first_not_of(basic_string_ref s) const ;
-    size_type find_first_not_of(charT c) const ;
-    size_type find_last_not_of(basic_string_ref s) const ;
-    size_type find_last_not_of(charT c) const ;
+    size_type find_first_of(basic_string_ref s) const BOOST_NOEXCEPT ;
+    size_type find_last_of(basic_string_ref s) const BOOST_NOEXCEPT ;
+    size_type find_first_not_of(basic_string_ref s) const BOOST_NOEXCEPT ;
+    size_type find_first_not_of(charT c) const BOOST_NOEXCEPT ;
+    size_type find_last_not_of(basic_string_ref s) const BOOST_NOEXCEPT ;
+    size_type find_last_not_of(charT c) const BOOST_NOEXCEPT ;
 
 String-like operations:
 
     BOOST_CONSTEXPR basic_string_ref substr(size_type pos, size_type n=npos) const ; // Creates a new string_ref
-    int compare(basic_string_ref x) const ; // like std::string::compare
+    int compare(basic_string_ref x) const BOOST_NOEXCEPT ; // like std::string::compare
     // The following methods were removed from proposal in N3685
     bool starts_with(charT c) const ;
     bool starts_with(basic_string_ref x) const ;

--- a/doc/string_ref.qbk
+++ b/doc/string_ref.qbk
@@ -157,6 +157,12 @@ String-like operations:
 
     BOOST_CONSTEXPR basic_string_ref substr(size_type pos=npos, size_type n=npos) const ; // Creates a new string_ref
     int compare(basic_string_ref x) const BOOST_NOEXCEPT ; // like std::string::compare
+    int compare(size_type pos1, size_type n1, basic_string_ref str) const ;
+    int compare(size_type pos1, size_type n1, basic_string_ref str,
+                size_type pos2, size_type n2) const ;
+    int compare(const charT* s) const ;
+    int compare(size_type pos1, size_type n1, const charT* s) const ;
+    int compare(size_type pos1, size_type n1, const charT* s, size_type n2) const ;
     size_type copy(charT* s, size_type n, size_type pos=0) const ; // like std::copy_n
     // The following methods were removed from proposal in N3685
     bool starts_with(charT c) const ;

--- a/doc/string_ref.qbk
+++ b/doc/string_ref.qbk
@@ -7,8 +7,8 @@
 
 [article String_Ref
     [quickbook 1.5]
-    [authors [Clow, Marshall]]
-    [copyright 2012 Marshall Clow]
+    [authors [Clow, Marshall] [Bigot, Peter A.]]
+    [copyright 2012 2013 Marshall Clow, Peter A. Bigot]
     [license
         Distributed under the Boost Software License, Version 1.0.
         (See accompanying file LICENSE_1_0.txt or copy at
@@ -171,6 +171,28 @@ String-like operations:
     bool ends_with(basic_string_ref x) const ;
 
 Note that `starts_with` and `ends_with` were removed from the proposed interface in N3685 but are currently retained in Boost.
+
+[endsect]
+
+[/===============]
+[section Conformance to Proposed Standard]
+[/===============]
+
+Boost.StringRef differs from [@http://isocpp.org/files/papers/N3762.html N3762: string_view: a non-owning reference to a string, revision 5] in the following particulars:
+
+# The proposed template name changed from `string_ref` to `string_view` at [@http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3609.html N3609].  At this time the new name is not supported.
+
+# Using the default constructor `string_ref()` produces an object that returns a null pointer from `data()`.  N3762 requires that `data()` never return a null pointer.
+
+# Boost's implementation adds the following non-standard member functions:
+
+  # `to_string`
+  # `starts_with` (removed in [@http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3685.html N3685])
+  # `ends_with` (removed in [@http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3685.html N3685])
+
+# [@http://isocpp.org/files/papers/N3762.html#string.view.nonmem non-member `to_string`] is not provided.
+
+# `const charT*` overloads for member functions in [@http://isocpp.org/files/papers/N3762.html#h5o-6 string.view.find] that are not documented are not provided.  The `charT` overloads are provided.
 
 [endsect]
 

--- a/include/boost/utility/string_ref.hpp
+++ b/include/boost/utility/string_ref.hpp
@@ -42,7 +42,7 @@ namespace boost {
 
     template<typename charT, typename traits>
     class basic_string_ref {
-        bool inline is_cleared_ () const { return ptr_ == &nul_; }
+        bool inline is_cleared_ () const { return !ptr_; }
     public:
         // types
         typedef traits traits_type;
@@ -61,19 +61,15 @@ namespace boost {
 
         // construct/copy
         BOOST_CONSTEXPR basic_string_ref () BOOST_NOEXCEPT
-            : ptr_(&nul_), len_(0) {}
+            : ptr_(NULL), len_(0) {}
 
         BOOST_CONSTEXPR basic_string_ref (const basic_string_ref &rhs) BOOST_NOEXCEPT :
-            ptr_(rhs.is_cleared_() ? &nul_ : rhs.ptr_),
+            ptr_(rhs.ptr_),
             len_(rhs.len_) { }
 
         basic_string_ref& operator=(const basic_string_ref &rhs) BOOST_NOEXCEPT {
-            if (rhs.is_cleared_()) {
-                clear();
-            } else {
-                ptr_ = rhs.ptr_;
-                len_ = rhs.len_;
-            }
+            ptr_ = rhs.ptr_;
+            len_ = rhs.len_;
             return *this;
             }
 
@@ -139,10 +135,10 @@ namespace boost {
 
         BOOST_CONSTEXPR const charT& front() const { return ptr_[0]; }
         BOOST_CONSTEXPR const charT& back()  const { return ptr_[len_-1]; }
-        BOOST_CONSTEXPR const charT* data()  const BOOST_NOEXCEPT { return ptr_; }
+        BOOST_CONSTEXPR const charT* data()  const BOOST_NOEXCEPT { return ptr_ ? ptr_ : &nul_; }
 
         // modifiers
-        void clear() BOOST_NOEXCEPT { len_ = 0; ptr_ = &nul_; }
+        void clear() BOOST_NOEXCEPT { len_ = 0; ptr_ = NULL; }
         void remove_prefix(size_type n) {
             if ( n > len_ )
                 n = len_;
@@ -172,7 +168,8 @@ namespace boost {
                 BOOST_THROW_EXCEPTION( std::out_of_range ( "string_ref::substr" ) );
             if ( n == npos || pos + n > size())
                 n = size () - pos;
-            return basic_string_ref ( data() + pos, n );
+            const charT * np = ptr_ ? (ptr_ + pos) : NULL;
+            return basic_string_ref ( np, n );
             }
 
         int compare(basic_string_ref x) const BOOST_NOEXCEPT {

--- a/include/boost/utility/string_ref.hpp
+++ b/include/boost/utility/string_ref.hpp
@@ -59,13 +59,13 @@ namespace boost {
         static BOOST_CONSTEXPR_OR_CONST size_type npos = size_type(-1);
 
         // construct/copy
-        BOOST_CONSTEXPR basic_string_ref ()
+        BOOST_CONSTEXPR basic_string_ref () BOOST_NOEXCEPT
             : ptr_(NULL), len_(0) {}
 
-        BOOST_CONSTEXPR basic_string_ref (const basic_string_ref &rhs)
+        BOOST_CONSTEXPR basic_string_ref (const basic_string_ref &rhs) BOOST_NOEXCEPT
             : ptr_(rhs.ptr_), len_(rhs.len_) {}
 
-        basic_string_ref& operator=(const basic_string_ref &rhs) {
+        basic_string_ref& operator=(const basic_string_ref &rhs) BOOST_NOEXCEPT {
             ptr_ = rhs.ptr_;
             len_ = rhs.len_;
             return *this;
@@ -75,7 +75,7 @@ namespace boost {
             : ptr_(str), len_(traits::length(str)) {}
 
         template<typename Allocator>
-        basic_string_ref(const std::basic_string<charT, traits, Allocator>& str)
+        basic_string_ref(const std::basic_string<charT, traits, Allocator>& str) BOOST_NOEXCEPT
             : ptr_(str.data()), len_(str.length()) {}
 
         BOOST_CONSTEXPR basic_string_ref(const charT* str, size_type len)
@@ -93,20 +93,20 @@ namespace boost {
             }
 
         // iterators
-        BOOST_CONSTEXPR const_iterator   begin() const { return ptr_; }
-        BOOST_CONSTEXPR const_iterator  cbegin() const { return ptr_; }
-        BOOST_CONSTEXPR const_iterator     end() const { return ptr_ + len_; }
-        BOOST_CONSTEXPR const_iterator    cend() const { return ptr_ + len_; }
-                const_reverse_iterator  rbegin() const { return const_reverse_iterator (end()); }
-                const_reverse_iterator crbegin() const { return const_reverse_iterator (end()); }
-                const_reverse_iterator    rend() const { return const_reverse_iterator (begin()); }
-                const_reverse_iterator   crend() const { return const_reverse_iterator (begin()); }
+        BOOST_CONSTEXPR const_iterator   begin() const BOOST_NOEXCEPT { return ptr_; }
+        BOOST_CONSTEXPR const_iterator  cbegin() const BOOST_NOEXCEPT { return ptr_; }
+        BOOST_CONSTEXPR const_iterator     end() const BOOST_NOEXCEPT { return ptr_ + len_; }
+        BOOST_CONSTEXPR const_iterator    cend() const BOOST_NOEXCEPT { return ptr_ + len_; }
+                const_reverse_iterator  rbegin() const BOOST_NOEXCEPT { return const_reverse_iterator (end()); }
+                const_reverse_iterator crbegin() const BOOST_NOEXCEPT { return const_reverse_iterator (end()); }
+                const_reverse_iterator    rend() const BOOST_NOEXCEPT { return const_reverse_iterator (begin()); }
+                const_reverse_iterator   crend() const BOOST_NOEXCEPT { return const_reverse_iterator (begin()); }
 
         // capacity
-        BOOST_CONSTEXPR size_type size()     const { return len_; }
-        BOOST_CONSTEXPR size_type length()   const { return len_; }
-        BOOST_CONSTEXPR size_type max_size() const { return len_; }
-        BOOST_CONSTEXPR bool empty()         const { return len_ == 0; }
+        BOOST_CONSTEXPR size_type size()     const BOOST_NOEXCEPT { return len_; }
+        BOOST_CONSTEXPR size_type length()   const BOOST_NOEXCEPT { return len_; }
+        BOOST_CONSTEXPR size_type max_size() const BOOST_NOEXCEPT { return len_; }
+        BOOST_CONSTEXPR bool empty()         const BOOST_NOEXCEPT { return len_ == 0; }
 
         // element access
         BOOST_CONSTEXPR const charT& operator[](size_type pos) const { return ptr_[pos]; }
@@ -119,10 +119,10 @@ namespace boost {
 
         BOOST_CONSTEXPR const charT& front() const { return ptr_[0]; }
         BOOST_CONSTEXPR const charT& back()  const { return ptr_[len_-1]; }
-        BOOST_CONSTEXPR const charT* data()  const { return ptr_; }
+        BOOST_CONSTEXPR const charT* data()  const BOOST_NOEXCEPT { return ptr_; }
 
         // modifiers
-        void clear() { len_ = 0; }
+        void clear() BOOST_NOEXCEPT { len_ = 0; }
         void remove_prefix(size_type n) {
             if ( n > len_ )
                 n = len_;
@@ -146,7 +146,7 @@ namespace boost {
             return basic_string_ref ( data() + pos, n );
             }
 
-        int compare(basic_string_ref x) const {
+        int compare(basic_string_ref x) const BOOST_NOEXCEPT {
             const int cmp = traits::compare ( ptr_, x.ptr_, (std::min)(len_, x.len_));
             return cmp != 0 ? cmp : ( len_ == x.len_ ? 0 : len_ < x.len_ ? -1 : 1 );
             }
@@ -161,63 +161,63 @@ namespace boost {
             return len_ >= x.len_ && traits::compare ( ptr_ + len_ - x.len_, x.ptr_, x.len_ ) == 0;
             }
 
-        size_type find(basic_string_ref s) const {
+        size_type find(basic_string_ref s) const BOOST_NOEXCEPT {
             const_iterator iter = std::search ( this->cbegin (), this->cend (),
                                                 s.cbegin (), s.cend (), traits::eq );
             return iter == this->cend () ? npos : std::distance ( this->cbegin (), iter );
             }
 
-        size_type find(charT c) const {
+        size_type find(charT c) const BOOST_NOEXCEPT {
             const_iterator iter = std::find_if ( this->cbegin (), this->cend (),
                                     detail::string_ref_traits_eq<charT, traits> ( c ));
             return iter == this->cend () ? npos : std::distance ( this->cbegin (), iter );
             }
 
-        size_type rfind(basic_string_ref s) const {
+        size_type rfind(basic_string_ref s) const BOOST_NOEXCEPT {
             const_reverse_iterator iter = std::search ( this->crbegin (), this->crend (),
                                                 s.crbegin (), s.crend (), traits::eq );
             return iter == this->crend () ? npos : reverse_distance ( this->crbegin (), iter );
             }
 
-        size_type rfind(charT c) const {
+        size_type rfind(charT c) const BOOST_NOEXCEPT {
             const_reverse_iterator iter = std::find_if ( this->crbegin (), this->crend (),
                                     detail::string_ref_traits_eq<charT, traits> ( c ));
             return iter == this->crend () ? npos : reverse_distance ( this->crbegin (), iter );
             }
 
-        size_type find_first_of(charT c) const { return  find (c); }
-        size_type find_last_of (charT c) const { return rfind (c); }
+        size_type find_first_of(charT c) const BOOST_NOEXCEPT { return  find (c); }
+        size_type find_last_of (charT c) const BOOST_NOEXCEPT { return rfind (c); }
 
-        size_type find_first_of(basic_string_ref s) const {
+        size_type find_first_of(basic_string_ref s) const BOOST_NOEXCEPT {
             const_iterator iter = std::find_first_of
                 ( this->cbegin (), this->cend (), s.cbegin (), s.cend (), traits::eq );
             return iter == this->cend () ? npos : std::distance ( this->cbegin (), iter );
             }
 
-        size_type find_last_of(basic_string_ref s) const {
+        size_type find_last_of(basic_string_ref s) const BOOST_NOEXCEPT {
             const_reverse_iterator iter = std::find_first_of
                 ( this->crbegin (), this->crend (), s.cbegin (), s.cend (), traits::eq );
             return iter == this->crend () ? npos : reverse_distance ( this->crbegin (), iter);
             }
 
-        size_type find_first_not_of(basic_string_ref s) const {
+        size_type find_first_not_of(basic_string_ref s) const BOOST_NOEXCEPT {
             const_iterator iter = find_not_of ( this->cbegin (), this->cend (), s );
             return iter == this->cend () ? npos : std::distance ( this->cbegin (), iter );
             }
 
-        size_type find_first_not_of(charT c) const {
+        size_type find_first_not_of(charT c) const BOOST_NOEXCEPT {
             for ( const_iterator iter = this->cbegin (); iter != this->cend (); ++iter )
                 if ( !traits::eq ( c, *iter ))
                     return std::distance ( this->cbegin (), iter );
             return npos;
             }
 
-        size_type find_last_not_of(basic_string_ref s) const {
+        size_type find_last_not_of(basic_string_ref s) const BOOST_NOEXCEPT {
             const_reverse_iterator iter = find_not_of ( this->crbegin (), this->crend (), s );
             return iter == this->crend () ? npos : reverse_distance ( this->crbegin (), iter );
             }
 
-        size_type find_last_not_of(charT c) const {
+        size_type find_last_not_of(charT c) const BOOST_NOEXCEPT {
             for ( const_reverse_iterator iter = this->crbegin (); iter != this->crend (); ++iter )
                 if ( !traits::eq ( c, *iter ))
                     return reverse_distance ( this->crbegin (), iter );

--- a/include/boost/utility/string_ref.hpp
+++ b/include/boost/utility/string_ref.hpp
@@ -173,6 +173,22 @@ namespace boost {
             const int cmp = traits::compare ( ptr_, x.ptr_, (std::min)(len_, x.len_));
             return cmp != 0 ? cmp : ( len_ == x.len_ ? 0 : len_ < x.len_ ? -1 : 1 );
             }
+        int compare(size_type pos1, size_type n1, basic_string_ref s) const {
+            return substr(pos1, n1).compare(s);
+            }
+        int compare(size_type pos1, size_type n1, basic_string_ref s,
+                    size_type pos2, size_type n2) const {
+            return substr(pos1, n1).compare(s.substr(pos2, n2));
+            }
+        int compare(const charT* s) const {
+            return compare(basic_string_ref(s));
+            }
+        int compare(size_type pos1, size_type n1, const charT* s) const {
+            return substr(pos1, n1).compare(basic_string_ref(s));
+            }
+        int compare(size_type pos1, size_type n1, const charT* s, size_type n2) const {
+            return substr(pos1, n1).compare(basic_string_ref(s, n2));
+            }
 
         bool starts_with(charT c) const { return !empty() && traits::eq ( c, front()); }
         bool starts_with(basic_string_ref x) const {

--- a/include/boost/utility/string_ref.hpp
+++ b/include/boost/utility/string_ref.hpp
@@ -92,6 +92,20 @@ namespace boost {
             return std::basic_string<charT, traits> ( ptr_, len_ );
             }
 
+        size_type copy(charT* s, size_type n, size_type pos=0) const {
+            if ( pos > size() )
+                BOOST_THROW_EXCEPTION( std::out_of_range ( "string_ref::copy" ) );
+            size_t rlen = size() - pos;
+            if ( n < rlen )
+                rlen = n;
+            else
+                n = rlen;
+            const_iterator first = begin() + pos;
+            for ( ; n > 0; --n, ++first, ++s )
+                *s = *first;
+            return rlen;
+        }
+
         // iterators
         BOOST_CONSTEXPR const_iterator   begin() const BOOST_NOEXCEPT { return ptr_; }
         BOOST_CONSTEXPR const_iterator  cbegin() const BOOST_NOEXCEPT { return ptr_; }

--- a/include/boost/utility/string_ref.hpp
+++ b/include/boost/utility/string_ref.hpp
@@ -150,6 +150,15 @@ namespace boost {
             len_ -= n;
             }
 
+        void swap(basic_string_ref& s) BOOST_NOEXCEPT {
+            const charT *ptr = ptr_;
+            std::size_t len = len_;
+            ptr_ = s.ptr_;
+            s.ptr_ = ptr;
+            len_ = s.len_;
+            s.len_ = len;
+        }
+
 
         // basic_string_ref string operations
         basic_string_ref substr(size_type pos=0, size_type n=npos) const {

--- a/include/boost/utility/string_ref.hpp
+++ b/include/boost/utility/string_ref.hpp
@@ -44,8 +44,10 @@ namespace boost {
     class basic_string_ref {
     public:
         // types
+        typedef traits traits_type;
         typedef charT value_type;
         typedef const charT* pointer;
+        typedef const charT* const_pointer;
         typedef const charT& reference;
         typedef const charT& const_reference;
         typedef pointer const_iterator; // impl-defined

--- a/include/boost/utility/string_ref.hpp
+++ b/include/boost/utility/string_ref.hpp
@@ -190,13 +190,13 @@ namespace boost {
         size_type rfind(basic_string_ref s) const BOOST_NOEXCEPT {
             const_reverse_iterator iter = std::search ( this->crbegin (), this->crend (),
                                                 s.crbegin (), s.crend (), traits::eq );
-            return iter == this->crend () ? npos : reverse_distance ( this->crbegin (), iter );
+            return iter == this->crend () ? npos : ( std::distance( iter, this->crend() ) - s.len_ );
             }
 
         size_type rfind(charT c) const BOOST_NOEXCEPT {
             const_reverse_iterator iter = std::find_if ( this->crbegin (), this->crend (),
                                     detail::string_ref_traits_eq<charT, traits> ( c ));
-            return iter == this->crend () ? npos : reverse_distance ( this->crbegin (), iter );
+            return iter == this->crend () ? npos : ( std::distance( iter, this->crend() ) - 1 );
             }
 
         size_type find_first_of(charT c) const BOOST_NOEXCEPT { return  find (c); }
@@ -211,7 +211,7 @@ namespace boost {
         size_type find_last_of(basic_string_ref s) const BOOST_NOEXCEPT {
             const_reverse_iterator iter = std::find_first_of
                 ( this->crbegin (), this->crend (), s.cbegin (), s.cend (), traits::eq );
-            return iter == this->crend () ? npos : reverse_distance ( this->crbegin (), iter);
+            return iter == this->crend () ? npos : ( std::distance ( iter, this->crend () ) - 1 );
             }
 
         size_type find_first_not_of(basic_string_ref s) const BOOST_NOEXCEPT {
@@ -228,22 +228,17 @@ namespace boost {
 
         size_type find_last_not_of(basic_string_ref s) const BOOST_NOEXCEPT {
             const_reverse_iterator iter = find_not_of ( this->crbegin (), this->crend (), s );
-            return iter == this->crend () ? npos : reverse_distance ( this->crbegin (), iter );
+            return iter == this->crend () ? npos : ( std::distance ( iter, this->crend () ) - 1 );
             }
 
         size_type find_last_not_of(charT c) const BOOST_NOEXCEPT {
             for ( const_reverse_iterator iter = this->crbegin (); iter != this->crend (); ++iter )
                 if ( !traits::eq ( c, *iter ))
-                    return reverse_distance ( this->crbegin (), iter );
+                    return std::distance ( iter, this->crend () ) - 1;
             return npos;
             }
 
     private:
-        template <typename r_iter>
-        size_type reverse_distance ( r_iter first, r_iter last ) const {
-            return len_ - 1 - std::distance ( first, last );
-            }
-
         template <typename Iterator>
         Iterator find_not_of ( Iterator first, Iterator last, basic_string_ref s ) const {
             for ( ; first != last ; ++first )

--- a/include/boost/utility/string_ref.hpp
+++ b/include/boost/utility/string_ref.hpp
@@ -122,7 +122,7 @@ namespace boost {
         BOOST_CONSTEXPR const charT* data()  const BOOST_NOEXCEPT { return ptr_; }
 
         // modifiers
-        void clear() BOOST_NOEXCEPT { len_ = 0; }
+        void clear() BOOST_NOEXCEPT { len_ = 0; ptr_ = NULL; }
         void remove_prefix(size_type n) {
             if ( n > len_ )
                 n = len_;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -39,6 +39,7 @@ test-suite utility
         [ run ../shared_iterator_test.cpp ]
         [ run string_ref_test1.cpp unit_test_framework ]
         [ run string_ref_test2.cpp unit_test_framework ]
+        [ run string_ref_test3.cpp unit_test_framework ]
         [ run string_ref_test_io.cpp unit_test_framework ]
         [ run ../value_init_test.cpp ]
         [ run ../value_init_workaround_test.cpp ]

--- a/test/string_ref_test1.cpp
+++ b/test/string_ref_test1.cpp
@@ -28,8 +28,8 @@ void interop ( const std::string &str, string_ref ref ) {
 
 void null_tests ( const char *p ) {
 //  All zero-length string-refs should be equal
-    string_ref sr1; // NULL, 0
-    string_ref sr2 ( NULL, 0 );
+    string_ref sr1; // some empty string
+    string_ref sr2; // another empty string
     string_ref sr3 ( p, 0 );
     string_ref sr4 ( p );
     sr4.clear ();

--- a/test/string_ref_test3.cpp
+++ b/test/string_ref_test3.cpp
@@ -264,6 +264,55 @@ void test_swap ()
   BOOST_CHECK_EQUAL(sv1.size(), 7);
 }
 
+void test_compare ()
+{
+  typedef string_ref::size_type szt;
+  const char pe[] = "abc";
+  const char pl[] = "aac";
+  const char pg[] = "acc";
+
+  const char str[] = "abcdabc\0abcd";
+  string_ref svstr(str, sizeof(str)-1);
+  string_ref svstrz(str);
+  BOOST_CHECK_EQUAL(szt(13), sizeof(str));
+  BOOST_CHECK_EQUAL(szt(12), svstr.size());
+  BOOST_CHECK_EQUAL(szt(7), svstrz.size());
+
+  string_ref svpl(pl);
+  string_ref svpe(pe);
+  string_ref svpg(pg);
+
+  BOOST_CHECK(svstr.compare(svstr) == 0);
+
+  BOOST_CHECK(svstr.compare(svpe) > 0);
+  BOOST_CHECK(svpe.compare(svstr) < 0);
+
+  BOOST_CHECK(svstr.compare(0, svpe.size(), svpe) == 0);
+  BOOST_CHECK(svstr.compare(0, svpl.size(), svpl) > 0);
+  BOOST_CHECK(svstr.compare(0, svpg.size(), svpg) < 0);
+  BOOST_CHECK(svstr.compare(0, svpe.size(), pe) == 0);
+  BOOST_CHECK(svstr.compare(0, svpl.size(), pl) > 0);
+  BOOST_CHECK(svstr.compare(0, svpg.size(), pg) < 0);
+
+  BOOST_CHECK(svstr.substr(4).compare(svpe) > 0);
+  BOOST_CHECK(svstr.compare(4, string_ref::npos, svpe) > 0);
+
+  BOOST_CHECK(svpe.compare(svstr.substr(4)) < 0);
+  BOOST_CHECK(svpe.compare(svstr.substr(4, 3)) == 0);
+
+  BOOST_CHECK_EQUAL(svstr.data(), svstrz.data());
+  BOOST_CHECK(svstr.compare(svstrz) > 0);
+  BOOST_CHECK(svstr.compare(str) > 0);
+  BOOST_CHECK(svstrz.compare(svstr) < 0);
+
+  BOOST_CHECK(svstr.compare(0, string_ref::npos, svstrz) > 0);
+  BOOST_CHECK(svstr.compare(0, string_ref::npos, svstr) == 0);
+  BOOST_CHECK(svstr.compare(0, string_ref::npos, svstr.data()) > 0);
+  BOOST_CHECK(svstr.compare(0, string_ref::npos, svstr.data(), svstr.size()) == 0);
+  BOOST_CHECK(svstr.compare(0, string_ref::npos, svstr.data(), svstr.size()-1) > 0);
+  BOOST_CHECK(svstr.compare(0, svstr.size()-1, svstr.data(), svstr.size()) < 0);
+}
+
 BOOST_AUTO_TEST_CASE( test_main )
 {
   test_clear();
@@ -274,4 +323,5 @@ BOOST_AUTO_TEST_CASE( test_main )
   test_flo();
   test_flno();
   test_swap();
+  test_compare();
 }

--- a/test/string_ref_test3.cpp
+++ b/test/string_ref_test3.cpp
@@ -245,6 +245,24 @@ void test_flno ()
   BOOST_CHECK_EQUAL(szt(2), svabcz.find_last_not_of('\0'));
 }
 
+void test_swap ()
+{
+  const char * const cp1 = "one";
+  const char * const cp2 = "not one";
+  string_ref sv1(cp1);
+  string_ref sv2(cp2);
+  BOOST_CHECK_NE(sv1.data(), sv2.data());
+  BOOST_CHECK_NE(sv1.size(), sv2.size());
+  BOOST_CHECK_EQUAL(sv1.data(), cp1);
+  BOOST_CHECK_EQUAL(sv1.size(), 3);
+  BOOST_CHECK_EQUAL(sv2.data(), cp2);
+  BOOST_CHECK_EQUAL(sv2.size(), 7);
+  sv1.swap(sv2);
+  BOOST_CHECK_EQUAL(sv2.data(), cp1);
+  BOOST_CHECK_EQUAL(sv2.size(), 3);
+  BOOST_CHECK_EQUAL(sv1.data(), cp2);
+  BOOST_CHECK_EQUAL(sv1.size(), 7);
+}
 
 BOOST_AUTO_TEST_CASE( test_main )
 {
@@ -255,4 +273,5 @@ BOOST_AUTO_TEST_CASE( test_main )
   test_ffo();
   test_flo();
   test_flno();
+  test_swap();
 }

--- a/test/string_ref_test3.cpp
+++ b/test/string_ref_test3.cpp
@@ -20,11 +20,16 @@ void test_clear ()
   string_ref sv0;
   string_ref svn("1234");
 
+  BOOST_CHECK(NULL != sv0.data());
+  BOOST_CHECK_EQUAL(0, sv0.size());
   BOOST_CHECK_NE(sv0.data(), svn.data());
   BOOST_CHECK_NE(sv0.size(), svn.size());
   svn.clear();
-  BOOST_CHECK_EQUAL(sv0.data(), svn.data());
+  BOOST_CHECK(NULL != svn.data());
   BOOST_CHECK_EQUAL(sv0.size(), svn.size());
+  // Mandated by implementation not specification:
+  BOOST_CHECK_NE(static_cast<const void*>(sv0.data()),
+                 static_cast<const void*>(svn.data()));
 }
 
 void test_copy ()

--- a/test/string_ref_test3.cpp
+++ b/test/string_ref_test3.cpp
@@ -69,9 +69,19 @@ void test_find ()
 
   BOOST_CHECK_EQUAL(szt(12), sv.size());
   BOOST_CHECK_EQUAL(sv.find(svabc), 0);
-  BOOST_CHECK_EQUAL(sv.find(pabc), 0);
+  BOOST_CHECK_EQUAL(sv.find(svabc, 1), 4);
+  BOOST_CHECK_EQUAL(sv.find(svabc, 5), 8);
   BOOST_CHECK(sv.find(svnot) == string_ref::npos);
+  BOOST_CHECK(sv.find(svabc, 9) == string_ref::npos);
+  BOOST_CHECK_EQUAL(sv.find(pabc), 0);
+  BOOST_CHECK_EQUAL(sv.find(pabc, 1), 4);
+  BOOST_CHECK_EQUAL(sv.find(pabc, 5), 8);
+  BOOST_CHECK(sv.find(svnot.data()) == string_ref::npos);
   BOOST_CHECK_EQUAL(sv.find('a'), 0);
+  BOOST_CHECK_EQUAL(sv.find('a', 1), 4);
+  BOOST_CHECK_EQUAL(sv.find('a', 3), 4);
+  BOOST_CHECK_EQUAL(sv.find('a', 4), 4);
+  BOOST_CHECK_EQUAL(sv.find('a', 5), 8);
   BOOST_CHECK_EQUAL(sv.find('d'), 3);
   BOOST_CHECK_EQUAL(sv.find('\0'), 7);
   BOOST_CHECK(sv.find('n') == string_ref::npos);
@@ -84,13 +94,32 @@ void test_rfind ()
   string_ref sv(pstr, sizeof(pstr)-1);
   const char * pabc = "abc";
   string_ref svabc(pabc);
+  const char * pcd = "cd";
+  string_ref svcd(pcd);
   string_ref svnot("not");
 
   BOOST_CHECK_EQUAL(szt(12), sv.size());
   BOOST_CHECK_EQUAL(szt(8), sv.rfind(svabc));
+  BOOST_CHECK_EQUAL(szt(8), sv.rfind(svabc, 9));
+  BOOST_CHECK_EQUAL(szt(8), sv.rfind(svabc, 8));
+  BOOST_CHECK_EQUAL(szt(4), sv.rfind(svabc, 7));
+  BOOST_CHECK_EQUAL(szt(4), sv.rfind(svabc, 5));
+  BOOST_CHECK_EQUAL(szt(4), sv.rfind(svabc, 4));
+  BOOST_CHECK_EQUAL(szt(0), sv.rfind(svabc, 0));
+  BOOST_CHECK_EQUAL(szt(2), sv.rfind(svcd, 5));
+  BOOST_CHECK(sv.rfind(svcd, 1) == string_ref::npos);
   BOOST_CHECK_EQUAL(szt(8), sv.rfind(pabc));
+  BOOST_CHECK_EQUAL(szt(8), sv.rfind(pabc, 9));
+  BOOST_CHECK_EQUAL(szt(8), sv.rfind(pabc, 8));
+  BOOST_CHECK_EQUAL(szt(4), sv.rfind(pabc, 7));
+  BOOST_CHECK_EQUAL(szt(4), sv.rfind(pabc, 5));
+  BOOST_CHECK_EQUAL(szt(4), sv.rfind(pabc, 4));
+  BOOST_CHECK_EQUAL(szt(0), sv.rfind(pabc, 0));
   BOOST_CHECK(sv.rfind(svnot) == string_ref::npos);
   BOOST_CHECK_EQUAL(szt(8), sv.rfind('a'));
+  BOOST_CHECK_EQUAL(szt(8), sv.rfind('a', 9));
+  BOOST_CHECK_EQUAL(szt(8), sv.rfind('a', 8));
+  BOOST_CHECK_EQUAL(szt(4), sv.rfind('a', 7));
   BOOST_CHECK_EQUAL(szt(7), sv.rfind('\0'));
   BOOST_CHECK_EQUAL(szt(11), sv.rfind('d'));
   BOOST_CHECK(sv.rfind('n') == string_ref::npos);
@@ -110,10 +139,19 @@ void test_ffo ()
   string_ref svnot("not");
 
   BOOST_CHECK_EQUAL(szt(0), sv.find_first_of(svabc));
+  BOOST_CHECK_EQUAL(szt(4), sv.find_first_of(svabc, 3));
+  BOOST_CHECK_EQUAL(szt(4), sv.find_first_of(svabc, 4));
+  BOOST_CHECK_EQUAL(szt(5), sv.find_first_of(svabc, 5));
   BOOST_CHECK_EQUAL(szt(3), sv.find_first_of(svdef));
+  BOOST_CHECK_EQUAL(szt(3), sv.find_first_of(svdef, 3));
+  BOOST_CHECK_EQUAL(szt(11), sv.find_first_of(svdef, 4));
   BOOST_CHECK_EQUAL(szt(7), sv.find_first_of(svghiz));
   BOOST_CHECK(sv.find_first_of(svnot) == string_ref::npos);
   BOOST_CHECK_EQUAL(szt(0), sv.find_first_of('a'));
+  BOOST_CHECK_EQUAL(szt(4), sv.find_first_of('a', 1));
+  BOOST_CHECK_EQUAL(szt(8), sv.find_first_of('a', 7));
+  BOOST_CHECK_EQUAL(szt(8), sv.find_first_of('a', 8));
+  BOOST_CHECK(sv.find_first_of('a', 9) == string_ref::npos);
   BOOST_CHECK_EQUAL(szt(3), sv.find_first_of('d'));
   BOOST_CHECK_EQUAL(szt(7), sv.find_first_of('\0'));
   BOOST_CHECK(sv.find_first_of('n') == string_ref::npos);
@@ -135,9 +173,15 @@ void test_flo ()
   BOOST_CHECK_EQUAL(szt(10), sv.find_last_of(svabc));
   BOOST_CHECK_EQUAL(szt(11), sv.find_last_of(svdef));
   BOOST_CHECK_EQUAL(szt(7), sv.find_last_of(svghiz));
+  BOOST_CHECK_EQUAL(szt(7), sv.find_last_of(svghiz, 8));
+  BOOST_CHECK_EQUAL(szt(7), sv.find_last_of(svghiz, 7));
+  BOOST_CHECK(sv.find_last_of(svghiz, 6) == string_ref::npos);
   BOOST_CHECK(sv.find_last_of(svnot) == string_ref::npos);
   BOOST_CHECK_EQUAL(szt(8), sv.find_last_of('a'));
   BOOST_CHECK_EQUAL(szt(11), sv.find_last_of('d'));
+  BOOST_CHECK_EQUAL(szt(3), sv.find_last_of('d', 4));
+  BOOST_CHECK_EQUAL(szt(3), sv.find_last_of('d', 3));
+  BOOST_CHECK(sv.find_last_of('d', 2) == string_ref::npos);
   BOOST_CHECK_EQUAL(szt(7), sv.find_last_of('\0'));
   BOOST_CHECK(sv.find_last_of('n') == string_ref::npos);
 }
@@ -159,8 +203,13 @@ void test_ffno ()
 
   BOOST_CHECK_EQUAL(szt(3), sv.find_first_not_of(svabc));
   BOOST_CHECK_EQUAL(szt(7), sv.find_first_not_of(svabcd));
+  BOOST_CHECK_EQUAL(szt(7), sv.find_first_not_of(svabcd, 6));
+  BOOST_CHECK_EQUAL(szt(7), sv.find_first_not_of(svabcd, 7));
+  BOOST_CHECK(string_ref::npos == sv.find_first_not_of(svabcd, 8));
   BOOST_CHECK(string_ref::npos == sv.find_first_not_of(svabcdz));
   BOOST_CHECK_EQUAL(szt(1), sv.find_first_not_of('a'));
+  BOOST_CHECK_EQUAL(szt(11), sv.find_first_not_of('c', 11));
+  BOOST_CHECK(string_ref::npos == sv.find_first_not_of('d', 11));
   BOOST_CHECK_EQUAL(szt(0), sv.find_first_not_of('b'));
 }
 
@@ -182,9 +231,16 @@ void test_flno ()
   BOOST_CHECK_EQUAL(szt(11), sv.find_last_not_of(svabcz));
   BOOST_CHECK_EQUAL(szt(10), sv.find_last_not_of(svdef));
   BOOST_CHECK_EQUAL(szt(7), sv.find_last_not_of(svabcd));
+  BOOST_CHECK_EQUAL(szt(7), sv.find_last_not_of(svabcd, 8));
+  BOOST_CHECK_EQUAL(szt(7), sv.find_last_not_of(svabcd, 7));
+  BOOST_CHECK(string_ref::npos == sv.find_last_not_of(svabcd, 6));
   BOOST_CHECK(string_ref::npos == sv.find_last_not_of(svabcdz));
   BOOST_CHECK_EQUAL(szt(11), sv.find_last_not_of('c'));
   BOOST_CHECK_EQUAL(szt(10), sv.find_last_not_of('d'));
+  BOOST_CHECK_EQUAL(szt(4), sv.find_last_not_of('d', 4));
+  BOOST_CHECK_EQUAL(szt(2), sv.find_last_not_of('d', 3));
+  BOOST_CHECK_EQUAL(szt(0), sv.find_last_not_of('d', 0));
+  BOOST_CHECK(string_ref::npos == sv.find_last_not_of('a', 0));
   BOOST_CHECK_EQUAL(szt(3), svabcz.find_last_not_of('d'));
   BOOST_CHECK_EQUAL(szt(2), svabcz.find_last_not_of('\0'));
 }

--- a/test/string_ref_test3.cpp
+++ b/test/string_ref_test3.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright Peter A. Bigot 2013.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+
+#include <boost/utility/string_ref.hpp>
+
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
+using boost::string_ref;
+using namespace boost::unit_test;
+
+void test_clear ()
+{
+  string_ref sv0;
+  string_ref svn("1234");
+
+  BOOST_CHECK_NE(sv0.data(), svn.data());
+  BOOST_CHECK_NE(sv0.size(), svn.size());
+  svn.clear();
+  BOOST_CHECK_EQUAL(sv0.data(), svn.data());
+  BOOST_CHECK_EQUAL(sv0.size(), svn.size());
+}
+
+BOOST_AUTO_TEST_CASE( test_main )
+{
+  test_clear();
+}

--- a/test/string_ref_test3.cpp
+++ b/test/string_ref_test3.cpp
@@ -5,6 +5,8 @@
  *          http://www.boost.org/LICENSE_1_0.txt)
  */
 
+#include <algorithm>
+#include <stdexcept>
 #include <boost/utility/string_ref.hpp>
 
 #define BOOST_TEST_MAIN
@@ -25,7 +27,39 @@ void test_clear ()
   BOOST_CHECK_EQUAL(sv0.size(), svn.size());
 }
 
+void test_copy ()
+{
+  typedef string_ref::size_type szt;
+  string_ref sv("123456789A");
+  char buffer[4] = { 0 };
+  char * const ebuffer = buffer + sizeof(buffer) / sizeof(*buffer);
+
+  BOOST_CHECK_EQUAL(char(), buffer[0]);
+  BOOST_CHECK_EQUAL('1', sv[0]);
+
+  BOOST_CHECK_THROW(sv.copy(buffer, sizeof(buffer), string_ref::npos),
+                    std::out_of_range);
+  BOOST_CHECK_THROW(sv.copy(buffer, sizeof(buffer), sv.size()+1),
+                    std::out_of_range);
+
+  string_ref::size_type len = sv.copy(buffer, sizeof(buffer), 8);
+  BOOST_CHECK_EQUAL(szt(2), len);
+  BOOST_CHECK_EQUAL('9', buffer[0]);
+
+  std::fill(buffer, ebuffer, 0);
+  BOOST_CHECK_EQUAL(char(), buffer[0]);
+
+  len = sv.copy(buffer, sizeof(buffer), sv.size());
+  BOOST_CHECK_EQUAL(szt(0), len);
+  BOOST_CHECK_EQUAL(char(), buffer[0]);
+
+  len = sv.copy(buffer, sizeof(buffer), 0);
+  BOOST_CHECK_EQUAL(szt(4), len);
+  BOOST_CHECK(std::equal(buffer, ebuffer, sv.data()));
+}
+
 BOOST_AUTO_TEST_CASE( test_main )
 {
   test_clear();
+  test_copy();
 }

--- a/test/string_ref_test3.cpp
+++ b/test/string_ref_test3.cpp
@@ -58,8 +58,145 @@ void test_copy ()
   BOOST_CHECK(std::equal(buffer, ebuffer, sv.data()));
 }
 
+void test_find ()
+{
+  typedef string_ref::size_type szt;
+  const char pstr[] = "abcdabc\0abcd";
+  string_ref sv(pstr, sizeof(pstr)-1);
+  const char * pabc = "abc";
+  string_ref svabc(pabc);
+  string_ref svnot("not");
+
+  BOOST_CHECK_EQUAL(szt(12), sv.size());
+  BOOST_CHECK_EQUAL(sv.find(svabc), 0);
+  BOOST_CHECK_EQUAL(sv.find(pabc), 0);
+  BOOST_CHECK(sv.find(svnot) == string_ref::npos);
+  BOOST_CHECK_EQUAL(sv.find('a'), 0);
+  BOOST_CHECK_EQUAL(sv.find('d'), 3);
+  BOOST_CHECK_EQUAL(sv.find('\0'), 7);
+  BOOST_CHECK(sv.find('n') == string_ref::npos);
+}
+
+void test_rfind ()
+{
+  typedef string_ref::size_type szt;
+  const char pstr[] = "abcdabc\0abcd";
+  string_ref sv(pstr, sizeof(pstr)-1);
+  const char * pabc = "abc";
+  string_ref svabc(pabc);
+  string_ref svnot("not");
+
+  BOOST_CHECK_EQUAL(szt(12), sv.size());
+  BOOST_CHECK_EQUAL(szt(8), sv.rfind(svabc));
+  BOOST_CHECK_EQUAL(szt(8), sv.rfind(pabc));
+  BOOST_CHECK(sv.rfind(svnot) == string_ref::npos);
+  BOOST_CHECK_EQUAL(szt(8), sv.rfind('a'));
+  BOOST_CHECK_EQUAL(szt(7), sv.rfind('\0'));
+  BOOST_CHECK_EQUAL(szt(11), sv.rfind('d'));
+  BOOST_CHECK(sv.rfind('n') == string_ref::npos);
+}
+
+void test_ffo ()
+{
+  typedef string_ref::size_type szt;
+  const char pstr[] = "abcdabc\0abcd";
+  string_ref sv(pstr, sizeof(pstr)-1);
+  const char pabc[] = "abc";
+  const char pdef[] = "def";
+  const char pghi[] = "ghi";
+  string_ref svabc(pabc);
+  string_ref svdef(pdef);
+  string_ref svghiz(pghi, sizeof(pghi));
+  string_ref svnot("not");
+
+  BOOST_CHECK_EQUAL(szt(0), sv.find_first_of(svabc));
+  BOOST_CHECK_EQUAL(szt(3), sv.find_first_of(svdef));
+  BOOST_CHECK_EQUAL(szt(7), sv.find_first_of(svghiz));
+  BOOST_CHECK(sv.find_first_of(svnot) == string_ref::npos);
+  BOOST_CHECK_EQUAL(szt(0), sv.find_first_of('a'));
+  BOOST_CHECK_EQUAL(szt(3), sv.find_first_of('d'));
+  BOOST_CHECK_EQUAL(szt(7), sv.find_first_of('\0'));
+  BOOST_CHECK(sv.find_first_of('n') == string_ref::npos);
+}
+
+void test_flo ()
+{
+  typedef string_ref::size_type szt;
+  const char pstr[] = "abcdabc\0abcd";
+  string_ref sv(pstr, sizeof(pstr)-1);
+  const char pabc[] = "abc";
+  const char pdef[] = "def";
+  const char pghi[] = "ghi";
+  string_ref svabc(pabc);
+  string_ref svdef(pdef);
+  string_ref svghiz(pghi, sizeof(pghi));
+  string_ref svnot("not");
+
+  BOOST_CHECK_EQUAL(szt(10), sv.find_last_of(svabc));
+  BOOST_CHECK_EQUAL(szt(11), sv.find_last_of(svdef));
+  BOOST_CHECK_EQUAL(szt(7), sv.find_last_of(svghiz));
+  BOOST_CHECK(sv.find_last_of(svnot) == string_ref::npos);
+  BOOST_CHECK_EQUAL(szt(8), sv.find_last_of('a'));
+  BOOST_CHECK_EQUAL(szt(11), sv.find_last_of('d'));
+  BOOST_CHECK_EQUAL(szt(7), sv.find_last_of('\0'));
+  BOOST_CHECK(sv.find_last_of('n') == string_ref::npos);
+}
+
+void test_ffno ()
+{
+  typedef string_ref::size_type szt;
+  const char pstr[] = "abcdabc\0abcd";
+  string_ref sv(pstr, sizeof(pstr)-1);
+  const char pabc[] = "abc";
+  const char pabcd[] = "abcd";
+  const char pdef[] = "def";
+  const char pghi[] = "ghi";
+  string_ref svabc(pabc);
+  string_ref svabcd(pabcd);
+  string_ref svabcdz(pabcd, sizeof(pabcd));
+  string_ref svdef(pdef);
+  string_ref svghi(pghi);
+
+  BOOST_CHECK_EQUAL(szt(3), sv.find_first_not_of(svabc));
+  BOOST_CHECK_EQUAL(szt(7), sv.find_first_not_of(svabcd));
+  BOOST_CHECK(string_ref::npos == sv.find_first_not_of(svabcdz));
+  BOOST_CHECK_EQUAL(szt(1), sv.find_first_not_of('a'));
+  BOOST_CHECK_EQUAL(szt(0), sv.find_first_not_of('b'));
+}
+
+void test_flno ()
+{
+  typedef string_ref::size_type szt;
+  const char pstr[] = "abcdabc\0abcd";
+  string_ref sv(pstr, sizeof(pstr)-1);
+  const char pabc[] = "abc";
+  const char pabcd[] = "abcd";
+  const char pdef[] = "def";
+  const char pghi[] = "ghi";
+  string_ref svabcz(pabc, sizeof(pabc));
+  string_ref svabcd(pabcd);
+  string_ref svabcdz(pabcd, sizeof(pabcd));
+  string_ref svdef(pdef);
+  string_ref svghi(pghi);
+
+  BOOST_CHECK_EQUAL(szt(11), sv.find_last_not_of(svabcz));
+  BOOST_CHECK_EQUAL(szt(10), sv.find_last_not_of(svdef));
+  BOOST_CHECK_EQUAL(szt(7), sv.find_last_not_of(svabcd));
+  BOOST_CHECK(string_ref::npos == sv.find_last_not_of(svabcdz));
+  BOOST_CHECK_EQUAL(szt(11), sv.find_last_not_of('c'));
+  BOOST_CHECK_EQUAL(szt(10), sv.find_last_not_of('d'));
+  BOOST_CHECK_EQUAL(szt(3), svabcz.find_last_not_of('d'));
+  BOOST_CHECK_EQUAL(szt(2), svabcz.find_last_not_of('\0'));
+}
+
+
 BOOST_AUTO_TEST_CASE( test_main )
 {
   test_clear();
   test_copy();
+  test_find();
+  test_rfind();
+  test_ffo();
+  test_flo();
+  test_flno();
 }


### PR DESCRIPTION
This set of commits fixes several bugs in Boost.String_ref, and brings the interface closer to the current draft proposal.  The tests pass on gcc (4.6.3 + 4.9.0-dev, with and without -std=c++11) and with clang (3.0 and 3.4-dev).  The remaining interface inconsistencies are listed in the user documentation.
