### PR TITLE
Add BOOST_NO_IOSTREAM support to BOOST_ASSERT_MSG().

### DIFF
--- a/assert.html
+++ b/assert.html
@@ -77,6 +77,8 @@
         may produce easier to understand output if messages go to a different 
         stream, such as <code>std::cout</code>. Users may define <b>BOOST_ASSERT_MSG_OSTREAM</b> before including <STRONG>&lt;boost/assert.hpp&gt;</STRONG> 
         to specify a different output stream.&nbsp; </P>
+        <P>If <b>BOOST_NO_IOSTREAM</b> is defined, C stdio library is used instead of C++ iostream.
+        The output is sent to a FILE* <b>BOOST_ASSERT_MSG_FILE</b>. It defaults to <code>stderr</code></P>
 		<P>If the macro <STRONG>BOOST_ENABLE_ASSERT_HANDLER</STRONG> is defined when <STRONG>&lt;boost/assert.hpp&gt;</STRONG>
 			is included, instead of sending a error message to an output 
         stream, this expression is evaluated</P>

--- a/include/boost/assert.hpp
+++ b/include/boost/assert.hpp
@@ -81,15 +81,23 @@ namespace boost
   #ifndef BOOST_ASSERT_HPP
     #define BOOST_ASSERT_HPP
     #include <cstdlib>
-    #include <iostream>
+
+    #ifdef BOOST_NO_IOSTREAM
+      #include <cstdio>
+      #ifndef BOOST_ASSERT_MSG_FILE
+      # define BOOST_ASSERT_MSG_FILE stderr
+      #endif
+    #else
+      #include <iostream>
+      //  IDE's like Visual Studio perform better if output goes to std::cout or
+      //  some other stream, so allow user to configure output stream:
+      #ifndef BOOST_ASSERT_MSG_OSTREAM
+      # define BOOST_ASSERT_MSG_OSTREAM std::cerr
+      #endif
+    #endif
+
     #include <boost/config.hpp>
     #include <boost/current_function.hpp>
-
-    //  IDE's like Visual Studio perform better if output goes to std::cout or
-    //  some other stream, so allow user to configure output stream:
-    #ifndef BOOST_ASSERT_MSG_OSTREAM
-    # define BOOST_ASSERT_MSG_OSTREAM std::cerr
-    #endif
 
     namespace boost
     {
@@ -102,10 +110,17 @@ namespace boost
           BOOST_NOINLINE void assertion_failed_msg(CharT const * expr, char const * msg, char const * function,
             char const * file, long line)
           {
+          #ifdef BOOST_NO_IOSTREAM
+            std::fprintf(BOOST_ASSERT_MSG_FILE,
+              "***** Internal Program Error - assertion (%s) failed in %s:\n"
+              "%s(%d): %s\n",
+              expr, function, file, line, msg);
+          #else
             BOOST_ASSERT_MSG_OSTREAM
               << "***** Internal Program Error - assertion (" << expr << ") failed in "
               << function << ":\n"
               << file << '(' << line << "): " << msg << std::endl;
+          #endif
 #ifdef UNDER_CE
             // The Windows CE CRT library does not have abort() so use exit(-1) instead.
             std::exit(-1);


### PR DESCRIPTION
And introduce BOOST_ASSERT_MSG_FILE to configure the output stream like
BOOST_ASSERT_MSG_OSTREAM.

Use of iostream can be an obstacle to use libraries which uses
BOOST_ASSERT_MSG() on some poor (about hardware, compiler, etc)
environments.
