### PR TITLE
Cast signed integral types to unsigned to left shift a negative integral constant

### DIFF
--- a/numeric_traits_test.cpp
+++ b/numeric_traits_test.cpp
@@ -68,9 +68,9 @@ struct complement
         BOOST_STATIC_CONSTANT(Number, min = Number((prev::min) << CHAR_BIT));
 #else
         BOOST_STATIC_CONSTANT(Number, max =
-                            Number(Number(prev::max) << CHAR_BIT)
+                            Number(typename boost::make_unsigned<Number>::type(prev::max) << CHAR_BIT)
                             + Number(UCHAR_MAX));
-        BOOST_STATIC_CONSTANT(Number, min = Number(Number(prev::min) << CHAR_BIT));
+        BOOST_STATIC_CONSTANT(Number, min = Number(typename boost::make_unsigned<Number>::type(prev::min) << CHAR_BIT));
 #endif
    
     };


### PR DESCRIPTION
Clang refuses to compile a left shift of a negative integral constant, so I'll leverage the hopefully sane behaviour of casting to an unsigned type for the intermediate result.

I've intentionally left gcc 4.0.2 out of this as I'll assume it does the right thing and may or may not handle the make_unsigned.

I've tested on linux with Clang 3.4 and 3.5, as well as gcc 4.8.2 all with std=c++11.

Opinions on whether a static_cast would be preferable to a c-style cast are accepted, but since the c-style cast is used throughout, I stuck with that.
