### PR TITLE
Fix compilation with gcc 4.5 in C++11 mode

### DIFF
--- a/include/boost/noncopyable.hpp
+++ b/include/boost/noncopyable.hpp
@@ -22,19 +22,19 @@ namespace noncopyable_  // protection from unintended ADL
 {
   class noncopyable
   {
-   protected:
-#ifndef BOOST_NO_DEFAULTED_FUNCTIONS
-    BOOST_CONSTEXPR noncopyable() = default;
-    ~noncopyable() = default;
+  protected:
+#if !defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS) && !defined(BOOST_NO_CXX11_NON_PUBLIC_DEFAULTED_FUNCTIONS)
+      BOOST_CONSTEXPR noncopyable() = default;
+      ~noncopyable() = default;
 #else
-    noncopyable() {}
+      noncopyable() {}
       ~noncopyable() {}
 #endif
-#ifndef BOOST_NO_DELETED_FUNCTIONS
-        noncopyable( const noncopyable& ) = delete;
-        noncopyable& operator=( const noncopyable& ) = delete;
+#if !defined(BOOST_NO_CXX11_DELETED_FUNCTIONS)
+      noncopyable( const noncopyable& ) = delete;
+      noncopyable& operator=( const noncopyable& ) = delete;
 #else
-    private:  // emphasize the following members are private
+  private:  // emphasize the following members are private
       noncopyable( const noncopyable& );
       noncopyable& operator=( const noncopyable& );
 #endif


### PR DESCRIPTION
Gcc 4.5 does not allow non-public defaulted functions, so fall back to the C++03 version. Also replaced the deprecated macros with the new ones and adjusted formatting.

Originated from: http://thread.gmane.org/gmane.comp.lib.boost.devel/250206
