### PR TITLE
removed comparison with 0

### DIFF
--- a/OptionalPointee.html
+++ b/OptionalPointee.html
@@ -57,10 +57,7 @@ aliasing.
   </TR>
   <TR>
     <TD VAlign=top>Validity Test</TD>
-    <TD VAlign=top>&nbsp;<tt>t</tt><br>
-     &nbsp;<tt>t != 0</tt><br>
-     &nbsp;<tt>!!t</tt>
-     </TD>
+    <TD VAlign=top>&nbsp;<tt>bool(t)</tt></TD>
     <TD VAlign=top>&nbsp;bool </TD>
     <TD VAlign=top>If the pointee is valid returns true.<br>
       If the pointee is invalid returns false.</TD>
@@ -68,9 +65,7 @@ aliasing.
   </TR>
   <TR>
     <TD VAlign=top>Invalidity Test</TD>
-    <TD VAlign=top>&nbsp;<tt>t == 0</tt><br>
-                   &nbsp;<tt>!t</tt>
-    </TD>
+    <TD VAlign=top>&nbsp;<tt>!t</tt></TD>
     <TD VAlign=top>&nbsp;bool </TD>
     <TD VAlign=top>If the pointee is valid returns false.<br>
       If the pointee is invalid returns true.</TD>


### PR DESCRIPTION
The concept is supposed to generalize pointers and optional<>, but the latter has abandoned the comparison with 0 a long while ago.
