### PR TITLE
Added base_from_member specialization for members of lvalue-reference ty...

### DIFF
--- a/base_from_member_ref_test.cpp
+++ b/base_from_member_ref_test.cpp
@@ -1,0 +1,29 @@
+//
+// Test that a base_from_member<T&> can be properly constructed
+//
+// Copyright 2014 Agustin Berge
+//
+// Distributed under the Boost Software License, Version 1.0.
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+
+#include <boost/utility/base_from_member.hpp>
+
+#include <boost/detail/lightweight_test.hpp>
+
+struct foo : boost::base_from_member<int&>
+{
+    explicit foo(int& ref) : boost::base_from_member<int&>(ref)
+    {
+        BOOST_TEST(&member == &ref);
+    }
+};
+
+int main()
+{
+    int i = 0;
+    foo f(i);
+
+    return boost::report_errors();
+}

--- a/doc/base_from_member.qbk
+++ b/doc/base_from_member.qbk
@@ -143,6 +143,16 @@ type does not need to concern itself with the integer.
     #endif
     };
 
+    template < typename MemberType, int UniqueID >
+    class base_from_member<MemberType&, UniqueID>
+    {
+    protected:
+        MemberType& member;
+
+        explicit constexpr base_from_member( MemberType& x )
+            noexcept;
+    };
+
 The class template has a first template parameter `MemberType` representing
 the type of the based-member. It has a last template parameter `UniqueID`,
 that is an `int`, to differentiate between multiple base classes that use
@@ -168,6 +178,9 @@ On earlier-standard compilers, there is a default constructor and several
 constructor member templates. These constructor templates can take as many
 arguments (currently up to ten) as possible and pass them to a constructor
 of the data member.
+
+A specialization for member references offers a single constructor taking
+a `MemberType&`, which is the only way to initialize a reference.
 
 Since C++ does not allow any way to explicitly state the template parameters
 of a templated constructor, make sure that the arguments are already close

--- a/include/boost/utility/base_from_member.hpp
+++ b/include/boost/utility/base_from_member.hpp
@@ -148,6 +148,19 @@ protected:
 
 };  // boost::base_from_member
 
+template < typename MemberType, int UniqueID >
+class base_from_member<MemberType&, UniqueID>
+{
+protected:
+    MemberType& member;
+
+    explicit BOOST_CONSTEXPR base_from_member( MemberType& x )
+        BOOST_NOEXCEPT
+        : member( x )
+        {}
+
+};  // boost::base_from_member
+
 }  // namespace boost
 
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -21,6 +21,7 @@ test-suite utility
         [ run ../addressof_test.cpp ]
         [ run ../addressof_test2.cpp ]
         [ run ../base_from_member_test.cpp ]
+        [ run ../base_from_member_ref_test.cpp ]
         [ run ../binary_test.cpp ]
         [ run ../call_traits_test.cpp : -u ]
         [ compile-fail ../checked_delete_test.cpp ]


### PR DESCRIPTION
[ see https://svn.boost.org/trac/boost/ticket/7577 for context ]

Thoughts? The partial specialization is not needed in C++11 mode, but it seems cleaner to provide it just as well. 
