### PR TITLE
Add a redirect for the compressed pair docs.

### DIFF
--- a/compressed_pair.htm
+++ b/compressed_pair.htm
@@ -1,0 +1,16 @@
+
+<!--
+Copyright 2014 Daniel James.
+Distributed under the Boost Software License, Version 1.0. (See accompanying
+file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+-->
+
+<html>
+<head>
+    <meta http-equiv="refresh" content="0; URL=doc/html/compressed_pair.html">
+</head>
+<body>
+Automatic redirection failed, please go to
+<a href="doc/html/compressed_pair.html">doc/html/compressed_pair.html</a>
+</body>
+</html>


### PR DESCRIPTION
To fix some broken links. This location is pretty much a permalink for the library's documentation, so there should be a redirect rather than fixing the incoming links.
