### PR TITLE
Remove deprecated include

### DIFF
--- a/include/boost/operators.hpp
+++ b/include/boost/operators.hpp
@@ -83,8 +83,9 @@
 #define BOOST_OPERATORS_HPP
 
 #include <boost/config.hpp>
-#include <boost/iterator.hpp>
 #include <boost/detail/workaround.hpp>
+
+#include <cstddef>
 
 #if defined(__sgi) && !defined(__GNUC__)
 #   pragma set woff 1234
@@ -891,13 +892,13 @@ template <class T,
           class R = V const &>
 struct input_iterator_helper
   : input_iteratable<T, P
-  , boost::iterator<std::input_iterator_tag, V, D, P, R
+  , std::iterator<std::input_iterator_tag, V, D, P, R
     > > {};
 
 template<class T>
 struct output_iterator_helper
   : output_iteratable<T
-  , boost::iterator<std::output_iterator_tag, void, void, void, void
+  , std::iterator<std::output_iterator_tag, void, void, void, void
   > >
 {
   T& operator*()  { return static_cast<T&>(*this); }
@@ -911,7 +912,7 @@ template <class T,
           class R = V&>
 struct forward_iterator_helper
   : forward_iteratable<T, P
-  , boost::iterator<std::forward_iterator_tag, V, D, P, R
+  , std::iterator<std::forward_iterator_tag, V, D, P, R
     > > {};
 
 template <class T,
@@ -921,7 +922,7 @@ template <class T,
           class R = V&>
 struct bidirectional_iterator_helper
   : bidirectional_iteratable<T, P
-  , boost::iterator<std::bidirectional_iterator_tag, V, D, P, R
+  , std::iterator<std::bidirectional_iterator_tag, V, D, P, R
     > > {};
 
 template <class T,
@@ -931,7 +932,7 @@ template <class T,
           class R = V&>
 struct random_access_iterator_helper
   : random_access_iteratable<T, P, D, R
-  , boost::iterator<std::random_access_iterator_tag, V, D, P, R
+  , std::iterator<std::random_access_iterator_tag, V, D, P, R
     > >
 {
   friend D requires_difference_operator(const T& x, const T& y) {


### PR DESCRIPTION
All that boost/iterator.hpp does is pull std::iterator into namespace boost. A comment in that header mentions: "This header is obsolete and will be deprecated."