### PR TITLE
fix compile error on basic_string_view::to_string when Allocator is user-defined

### DIFF
--- a/include/boost/utility/string_view.hpp
+++ b/include/boost/utility/string_view.hpp
@@ -157,7 +157,7 @@ namespace boost {
 
 #ifndef BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS
         template<typename Allocator = std::allocator<charT> >
-        std::basic_string<charT, traits> to_string(const Allocator& a = Allocator()) const {
+        std::basic_string<charT, traits, Allocator> to_string(const Allocator& a = Allocator()) const {
             return std::basic_string<charT, traits, Allocator>(begin(), end(), a);
             }
 #else


### PR DESCRIPTION
I guess it's a typo, but currently the return type of boost::basic_string_view< C, T, A>::template to_string< A1 >() is std::basic_string< C, T, std::allocator< C >>, while the return type inferred from the return statement is std::basic_string< C, T, A1> which I guess it is the original intended return type.

This patch is meant to fix this "typo" (if it really is) so that to_string can return any basic_string types using different allocators. Also, I added a testcase in string_view_test2.cpp to prevent this typo from happening again.