### PR TITLE
Fixing visual studio compilation of string_view::at()

### DIFF
--- a/include/boost/utility/string_view.hpp
+++ b/include/boost/utility/string_view.hpp
@@ -121,10 +121,13 @@ namespace boost {
         BOOST_CONSTEXPR const_reference operator[](size_type pos) const BOOST_NOEXCEPT { return ptr_[pos]; }
 
         BOOST_CONSTEXPR const_reference at(size_t pos) const {
+#ifndef _MSC_VER
             return pos >= len_ ? BOOST_THROW_EXCEPTION(std::out_of_range("boost::string_view::at")) : ptr_[pos];
-//             if ( pos >= len_ )
-//                 BOOST_THROW_EXCEPTION( std::out_of_range ( "boost::string_view::at" ) );
-//             return ptr_[pos];
+#else
+            if (pos >= len_)
+                BOOST_THROW_EXCEPTION(std::out_of_range("boost::string_view::at"));
+            return ptr_[pos];
+#endif
             }
 
         BOOST_CONSTEXPR const_reference front() const                { return ptr_[0]; }

--- a/include/boost/utility/string_view.hpp
+++ b/include/boost/utility/string_view.hpp
@@ -121,13 +121,7 @@ namespace boost {
         BOOST_CONSTEXPR const_reference operator[](size_type pos) const BOOST_NOEXCEPT { return ptr_[pos]; }
 
         BOOST_CONSTEXPR const_reference at(size_t pos) const {
-#ifndef _MSC_VER
-            return pos >= len_ ? BOOST_THROW_EXCEPTION(std::out_of_range("boost::string_view::at")) : ptr_[pos];
-#else
-            if (pos >= len_)
-                BOOST_THROW_EXCEPTION(std::out_of_range("boost::string_view::at"));
-            return ptr_[pos];
-#endif
+            return pos >= len_ ? BOOST_THROW_EXCEPTION(std::out_of_range("boost::string_view::at")), ptr_[0] : ptr_[pos];
             }
 
         BOOST_CONSTEXPR const_reference front() const                { return ptr_[0]; }


### PR DESCRIPTION
VS2013, VS2015 & VS2017RC don't like the ternary throwing an exception :
'return': cannot convert from 'void' to 'const char &'
I propose to fix that by using classic if when compiling on a windows platform.