### PR TITLE
Use non-deprecated include paths

### DIFF
--- a/include/boost/utility.hpp
+++ b/include/boost/utility.hpp
@@ -14,8 +14,8 @@
 #include <boost/utility/binary.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/utility/identity_type.hpp>
-#include <boost/checked_delete.hpp>
+#include <boost/core/checked_delete.hpp>
+#include <boost/core/noncopyable.hpp>
 #include <boost/next_prior.hpp>
-#include <boost/noncopyable.hpp>
 
 #endif  // BOOST_UTILITY_HPP


### PR DESCRIPTION
According to the comments in these two headers, the files in the core directory should be used instead.