### PR TITLE
Add array constructors for string_view

### DIFF
--- a/include/boost/utility/string_view.hpp
+++ b/include/boost/utility/string_view.hpp
@@ -101,6 +101,14 @@ namespace boost {
       BOOST_CONSTEXPR basic_string_view(const charT* str, size_type len)
         : ptr_(str), len_(len) {}
 
+      template<std::size_t N>
+      BOOST_CONSTEXPR basic_string_view(const charT (&str)[N])
+        : ptr_(str), len_(N-1) {}
+
+      template<std::size_t N>
+      BOOST_CONSTEXPR basic_string_view(const charT (&str)[N], bool full)
+        : ptr_(str), len(full ? N : N-1) {}
+
         // iterators
         BOOST_CONSTEXPR const_iterator   begin() const BOOST_NOEXCEPT { return ptr_; }
         BOOST_CONSTEXPR const_iterator  cbegin() const BOOST_NOEXCEPT { return ptr_; }


### PR DESCRIPTION
This additional constructor is intended to make constructing a constant expression string_view easier in C++11 and C++14. Consider the following code snippet: `constexpr boost::string_view my_string("Hello World!");` This won't compile in C++11/14 because this constructor will try to call `std::char_traits<char>::length()`, which wasn't made constexpr until the (upcoming) C++17 standard. This can be worked around by changing the line to `constexpr boost::string_view my_string("Hello World!", 12);`, but that is more error-prone, and makes it harder to update it later.

This new constructor makes use of the fact that the type of a string literal is `const char[N]` where `N` is the length of the string plus one (for the null character). With this change, when you compile the line `constexpr boost::string_view my_string("Hello World!");`, it sets the length to `N-1`, which is a constant expression. I also added a constructor that additionally takes a bool argument which, when true, sets the string length to `N` instead of `N-1`. This is for the use case where it's an actual character array (such as `{'H', 'e', 'l', 'l', 'o'}`) without a null terminator.

This constructor should be valid for all use cases, but it may pose a problem when the user defines a custom character traits class that overrides the `length()` function. If you think that may be a problem, then I can change this constructor to be in a partial template specification so it can only be used when the traits class is `std::char_traits<charT>`, where this trick is guaranteed to be valid.