### PR TITLE
Add test cases for std::reverse_iterator

### DIFF
--- a/test/next_prior_test.cpp
+++ b/test/next_prior_test.cpp
@@ -86,6 +86,13 @@ int test_main(int, char*[])
     BOOST_REQUIRE(minus_n_unsigned_test(x.begin(), x.end(), x.size()));
     BOOST_REQUIRE(minus_n_unsigned_test(y.begin(), y.end(), y.size()));
 
+    BOOST_REQUIRE(plus_one_test(x.rbegin(), x.rend(), y.begin()));
+    BOOST_REQUIRE(plus_n_test(x.rbegin(), x.rend(), y.begin()));
+    BOOST_REQUIRE(minus_one_test(x.rbegin(), x.rend(), y.end()));
+    BOOST_REQUIRE(minus_n_test(x.rbegin(), x.rend(), y.end()));
+    BOOST_REQUIRE(minus_n_unsigned_test(x.rbegin(), x.rend(), x.size()));
+    BOOST_REQUIRE(minus_n_unsigned_test(x.rbegin(), x.rend(), y.size()));
+
     // Tests with integers
     BOOST_REQUIRE(boost::next(5) == 6);
     BOOST_REQUIRE(boost::next(5, 7) == 12);


### PR DESCRIPTION
Extend next_prior_test.cpp to demonstrate std::reverse_iterator with boost::next() and boost::prior().  

Motivated by [bug 13002](https://svn.boost.org/trac10/ticket/13002).