### PR TITLE
result_of<F&(…)> fails on MSVC-12 if F is a function pointer

### DIFF
--- a/include/boost/utility/detail/result_of_iterate.hpp
+++ b/include/boost/utility/detail/result_of_iterate.hpp
@@ -82,15 +82,12 @@ struct BOOST_PP_CAT(result_of_callable_fun_2_, BOOST_PP_ITERATION())<R(BOOST_PP_
 };
 
 template<typename F>
-struct BOOST_PP_CAT(result_of_callable_fun_, BOOST_PP_ITERATION());
-
-template<typename F>
-struct BOOST_PP_CAT(result_of_callable_fun_, BOOST_PP_ITERATION())<F *>
+struct BOOST_PP_CAT(result_of_callable_fun_, BOOST_PP_ITERATION())
   : BOOST_PP_CAT(result_of_callable_fun_2_, BOOST_PP_ITERATION())<F>
 {};
 
 template<typename F>
-struct BOOST_PP_CAT(result_of_callable_fun_, BOOST_PP_ITERATION())<F &>
+struct BOOST_PP_CAT(result_of_callable_fun_, BOOST_PP_ITERATION())<F *>
   : BOOST_PP_CAT(result_of_callable_fun_2_, BOOST_PP_ITERATION())<F>
 {};
 
@@ -99,7 +96,7 @@ struct BOOST_PP_CAT(result_of_select_call_wrapper_type_, BOOST_PP_ITERATION())
   : mpl::eval_if<
         is_class<typename remove_reference<F>::type>,
         result_of_wrap_callable_class<F>,
-        mpl::identity<BOOST_PP_CAT(result_of_callable_fun_, BOOST_PP_ITERATION())<typename remove_cv<F>::type> >
+        mpl::identity<BOOST_PP_CAT(result_of_callable_fun_, BOOST_PP_ITERATION())<typename remove_cv<typename remove_reference<F>::type>::type> >
     >
 {};
 

--- a/test/result_of_test.cpp
+++ b/test/result_of_test.cpp
@@ -297,6 +297,12 @@ int main()
   BOOST_STATIC_ASSERT((is_same<result_of<const no_result_type_or_result_template<void>(void)>::type, cv_overload_check<const int> >::value));
   BOOST_STATIC_ASSERT((is_same<result_of<volatile no_result_type_or_result_template<void>(void)>::type, cv_overload_check<volatile int> >::value));
   BOOST_STATIC_ASSERT((is_same<result_of<const volatile no_result_type_or_result_template<void>(void)>::type, cv_overload_check<const volatile int> >::value));
+
+  BOOST_STATIC_ASSERT((is_same<result_of<func_ptr&(char, float)>::type, int>::value));
+  BOOST_STATIC_ASSERT((is_same<result_of<func_ptr const&(char, float)>::type, int>::value));
+  BOOST_STATIC_ASSERT((is_same<result_of<int_result_of&(double)>::type, int>::value));
+  BOOST_STATIC_ASSERT((is_same<result_of<int_result_of const&(double)>::type, int>::value));
+
 #if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
   BOOST_STATIC_ASSERT((is_same<result_of<no_result_type_or_result(int&&)>::type, short>::value));
   BOOST_STATIC_ASSERT((is_same<result_of<no_result_type_or_result(int&)>::type, int>::value));


### PR DESCRIPTION
Background
----------
For a callable object of type `F`, the correct usage of decltype-based `result_of` to compute the return type of its lvalue call is `result_of<F&(…)`. So I updated some codes in Boost.Iterator to fix the usage of `result_of` (e.g. boostorg/iterator#35). However, the regression test fails on MSVC-12 if `F` is a function pointer type. That compiler has N3276 decltype support but does not support expression SFINAE.


Analysis
--------
On compilers without the support of expression SFINAE, decltype-based `result_of<FP&(…)>` (**`FP` is a function pointer type**) fails to compile. For example, this code fails:
```
#define BOOST_NO_SFINAE_EXPR
#define BOOST_RESULT_OF_USE_DECLTYPE
#include <boost/utility/result_of.hpp>
typedef double(*FP)(int);
boost::result_of<FP&(int)> ouch;
```
This is because `result_of<FP&(…)>` tries to instantiate an incomplete type in the following instantiation chain ("A -> B" means "A attempts to instantiate B"):

1. `result_of_is_callable_<FP&, …>` -> `result_of_select_call_wrapper_type_<FP&>`
2. `result_of_select_call_wrapper_type_<FP&>` -> `result_of_callable_fun_<FP&>`
3. `result_of_callable_fun_<FP&>` -> `result_of_callable_fun_2_<FP>`

`result_of_callable_fun_2_<FP>` is an incomplete type, because the primary template of `result_of_callable_fun_2_` does not have definition and it has specialization only for function types.

This PR fixes up the problem by

- Make `result_of_select_call_wrapper_type_<F&>` instantiate `result_of_callable_fun_<F>` instead of `result_of_callable_fun_<F&>` (when `F` is not a class type).
- Remove `result_of_callable_fun_<F&>` and add `result_of_callable_fun_<F>`.

(Since I don't have MSVC, I've been running the code on old GCC that does not support expression SFINAE and on newer GCC with `#define BOOST_NO_SFINAE_EXPR`.)