### PR TITLE
value_restore impl

### DIFF
--- a/include/boost/utility.hpp
+++ b/include/boost/utility.hpp
@@ -15,6 +15,7 @@
 #include <boost/utility/base_from_member.hpp>
 #include <boost/utility/binary.hpp>
 #include <boost/utility/identity_type.hpp>
+#include <boost/utility/value_restore.hpp>
 
 #include <boost/core/addressof.hpp>
 #include <boost/core/enable_if.hpp>

--- a/include/boost/utility/value_restore.hpp
+++ b/include/boost/utility/value_restore.hpp
@@ -1,0 +1,123 @@
+#ifndef BOOST_UTILITY_VALUE_RESTORE_HPP
+#define BOOST_UTILITY_VALUE_RESTORE_HPP
+
+// MS compatible compilers support #pragma once
+#if defined(_MSC_VER)
+# pragma once
+#endif
+
+/////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+// value_restore.hpp:
+
+// (C) Copyright 2003-4 Pavel Vozenilek and Robert Ramey - http://www.rrsd.com.
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+//  See http://www.boost.org/libs/utility for updates, documentation, and revision history.
+
+// Inspired by Daryle Walker's iostate_saver concept.  This saves the original
+// value of a variable when a value_restore is constructed and restores
+// upon destruction.  Useful for being sure that state is restored to
+// variables upon exit from scope.
+
+
+#include <boost/config.hpp>
+#ifndef BOOST_NO_EXCEPTIONS
+    #include <exception>
+#endif
+#ifndef BOOST_NO_CXX11_SMART_PTR
+    #include <boost/move/unique_ptr.hpp>
+#else
+    #include <memory>
+#endif
+
+#include <boost/call_traits.hpp>
+#include <boost/noncopyable.hpp>
+#include <boost/type_traits/has_nothrow_copy.hpp>
+#include <boost/core/no_exceptions_support.hpp>
+
+#include <boost/mpl/eval_if.hpp>
+#include <boost/mpl/identity.hpp>
+
+namespace boost {
+
+template<class T>
+// T requirements:
+//  - POD or object semantic (cannot be reference, function, ...)
+//  - copy constructor
+//  - operator = (no-throw one preferred)
+class value_restore : private boost::noncopyable
+{
+private:
+    const T previous_value;
+    T & previous_ref;
+
+    struct restore {
+        static void invoke(T & previous_ref, const T & previous_value){
+            previous_ref = previous_value; // won't throw
+        }
+    };
+
+    struct restore_with_exception {
+        static void invoke(T & previous_ref, const T & previous_value){
+            BOOST_TRY{
+                previous_ref = previous_value;
+            } 
+            BOOST_CATCH(::std::exception &) { 
+                // we must ignore it - we are in destructor
+            }
+            BOOST_CATCH_END
+        }
+    };
+
+public:
+    value_restore(
+        T & object
+    ) : 
+        previous_value(object),
+        previous_ref(object) 
+    {}
+    
+    void operator() () {
+        #ifndef BOOST_NO_EXCEPTIONS
+            typedef typename mpl::eval_if<
+                has_nothrow_copy< T >,
+                mpl::identity<restore>,
+                mpl::identity<restore_with_exception>
+            >::type typex;
+            typex::invoke(previous_ref, previous_value);
+        #else
+            previous_ref = previous_value;
+        #endif
+    }
+
+}; // value_restore<>
+
+template <typename T>
+value_restore<T> make_value_restore(T & object) {
+    value_restore<T> value(object);
+    return value;
+}
+
+#ifndef BOOST_NO_CXX11_TEMPLATE_ALIASES
+
+    #ifndef BOOST_NO_CXX11_SMART_PTR
+        template <typename T>
+        using value_restore_ptr = std::unique_ptr<T, value_restore<T> >;
+    #else
+        template <typename T>
+        using value_restore_ptr = boost::movelib::unique_ptr<T, value_restore<T> >;
+    #endif
+
+    template <typename T>
+    value_restore_ptr<T> make_value_restore_ptr(T & object) {
+        value_restore_ptr<T> ptr(&object, value_restore<T>(object));
+        return ptr;
+    }
+
+#endif
+
+} // boost
+
+#endif //BOOST_UTILITY_VALUE_RESTORE_HPP

--- a/test/value_restore.cpp
+++ b/test/value_restore.cpp
@@ -1,0 +1,79 @@
+// Copyright 2010, Niels Dekker.
+// Copyright 2018, Oleg Abrosimov.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// Test program for boost::value_restore<T>.
+//
+// 1 Mart 2018 (Created) Oleg Abrosimov
+
+#include <boost/utility/value_restore.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+#include <string>
+
+namespace
+{
+  template <class T>
+  void test_value_restore(T& magic_value, const T& new_value)
+  {
+    const T old_value = magic_value;
+    // require different values for test
+    BOOST_TEST( old_value != new_value );
+    {
+#ifndef BOOST_NO_CXX11_TEMPLATE_ALIASES
+      boost::value_restore_ptr<T> ptr = boost::make_value_restore_ptr(magic_value);
+#else
+    #ifndef BOOST_NO_CXX11_SMART_PTR
+      typedef std::unique_ptr<T, boost::value_restore<T> > value_restore_ptr;
+    #else
+      typedef boost::movelib::unique_ptr<T, boost::value_restore<T> > value_restore_ptr;
+    #endif
+      value_restore_ptr ptr = 
+        value_restore_ptr(&magic_value, boost::make_value_restore(magic_value));
+#endif
+      magic_value = new_value;
+      BOOST_TEST( magic_value == new_value );
+      BOOST_TEST( *ptr == new_value );
+    }
+    BOOST_TEST( magic_value != new_value );
+    BOOST_TEST( magic_value == old_value );
+  }
+
+  struct foo
+  {
+    int data;
+  };
+
+  bool operator==(const foo& lhs, const foo& rhs)
+  {
+    return lhs.data == rhs.data;
+  }
+}
+
+
+// Tests boost::initialize for a fundamental type, a type with a
+// user-defined constructor, and a user-defined type without 
+// a user-defined constructor.
+int main()
+{
+
+  int magic_number = 42;
+  const int new_number = 43;
+  test_value_restore(magic_number, new_number);
+
+  // test for pointers
+  test_value_restore(&magic_number, &new_number);
+
+  std::string magic_string = "magic value";
+  const std::string new_string = "magic value 2";
+  test_value_restore(magic_string, new_string);
+
+  foo magic_foo = { 42 };
+  const foo new_magic_foo = { 43 };
+  test_value_restore(magic_foo, new_magic_foo);
+
+  return boost::report_errors();
+}


### PR DESCRIPTION
The `boost::serialization::state_saver` rethinked: http://www.boost.org/doc/libs/1_66_0/libs/serialization/doc/state_saver.html

usage pattern:

```c++
#include <boost/utility/value_restore.hpp>

void func(A & a)
    boost::value_restore_ptr<A> ptr = boost::make_value_restore_ptr(a);
    ... // alter state of a by calling non-const functions
    ... // call other functions
    // original state of a automatically restored on exit
}
```

The difference form the original `boost::serialization::state_saver` is that it is implemented as a `Deleter` concept and can be used with standard smart pointers. The `boost::value_restore_ptr` is actually a template alias for the `std::unique_ptr`, if available.
