### PR TITLE
Implicit string view cast

### DIFF
--- a/include/boost/utility/string_view.hpp
+++ b/include/boost/utility/string_view.hpp
@@ -31,6 +31,10 @@
 #include <cstring>
 #include <iosfwd>
 
+#ifndef BOOST_NO_CXX17_HDR_STRING_VIEW
+#include <string_view>
+#endif
+
 #if defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS) || (defined(BOOST_GCC) && ((BOOST_GCC+0) / 100) <= 406)
 // GCC 4.6 cannot handle a defaulted function with noexcept specifier
 #define BOOST_STRING_VIEW_NO_CXX11_DEFAULTED_NOEXCEPT_FUNCTIONS
@@ -108,6 +112,11 @@ namespace boost {
       BOOST_CONSTEXPR basic_string_view(const charT* str, size_type len)
         : ptr_(str), len_(len) {}
 
+#ifndef BOOST_NO_CXX17_HDR_STRING_VIEW
+    BOOST_CONSTEXPR basic_string_view(std::basic_string_view<charT, traits> view)
+        : ptr_(view.data()), len_(view.size()) {}
+#endif
+
         // iterators
         BOOST_CONSTEXPR const_iterator   begin() const BOOST_NOEXCEPT { return ptr_; }
         BOOST_CONSTEXPR const_iterator  cbegin() const BOOST_NOEXCEPT { return ptr_; }
@@ -134,6 +143,12 @@ namespace boost {
         BOOST_CONSTEXPR const_reference front() const                { return ptr_[0]; }
         BOOST_CONSTEXPR const_reference back()  const                { return ptr_[len_-1]; }
         BOOST_CONSTEXPR const_pointer data()    const BOOST_NOEXCEPT { return ptr_; }
+
+#ifndef BOOST_NO_CXX17_HDR_STRING_VIEW
+        operator std::basic_string_view<charT, traits>() const {
+            return std::basic_string_view<charT, traits>(ptr_, len_);
+            }
+#endif
 
         // modifiers
         void clear() BOOST_NOEXCEPT { len_ = 0; }          // Boost extension

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -32,6 +32,7 @@ run string_ref_test_io.cpp ;
 compile string_view_constexpr_test1.cpp ;
 run string_view_test1.cpp ;
 run string_view_test2.cpp ;
+run string_view_test3.cpp ;
 run string_view_test_io.cpp ;
 
 run value_init_test.cpp ;

--- a/test/string_view_test3.cpp
+++ b/test/string_view_test3.cpp
@@ -1,0 +1,59 @@
+#include <boost/config.hpp>
+#ifndef BOOST_NO_CXX17_HDR_STRING_VIEW
+#include <boost/utility/string_view.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+// Test support for implicit conversion to std::basic_string_view
+void test_implicit_string_view_cast()
+{
+    typedef char char_type;
+    typedef boost::basic_string_view< char_type > string_view_type;
+    typedef std::basic_string_view<char_type, std::char_traits<char_type>> std_string_view;
+
+    char const* input = "static string";
+
+    string_view_type boost_view(input);
+
+    std_string_view std_view = boost_view;
+
+    BOOST_TEST(std_view.data() == boost_view.data());
+    BOOST_TEST(std_view.size() == boost_view.size());
+}
+
+// Test support for construction and assignment from std::basic_string_view
+void test_string_view_construction()
+{
+    typedef char char_type;
+    typedef boost::basic_string_view< char_type > string_view_type;
+    typedef std::basic_string_view<char_type, std::char_traits<char_type>> std_string_view;
+
+    char const* input = "static string";
+
+    {
+      std_string_view std_view = input;
+
+      string_view_type boost_view(std_view);
+
+      BOOST_TEST(std_view.data() == boost_view.data());
+      BOOST_TEST(std_view.size() == boost_view.size());
+    }
+
+    {
+      std_string_view std_view = input;
+
+      string_view_type boost_view;
+      boost_view = std_view;
+
+      BOOST_TEST(std_view.data() == boost_view.data());
+      BOOST_TEST(std_view.size() == boost_view.size());
+    }
+}
+
+int main()
+{
+  test_implicit_string_view_cast();
+  return boost::report_errors();
+}
+#else
+int main() {}
+#endif


### PR DESCRIPTION
This patch allows `boost::basic_string_view` to now seamlessly interop with `std::basic_string_view`.