### PR TITLE
make string_view partially model Sequence concept

### DIFF
--- a/include/boost/utility/string_view.hpp
+++ b/include/boost/utility/string_view.hpp
@@ -108,6 +108,9 @@ namespace boost {
       BOOST_CONSTEXPR basic_string_view(const charT* str, size_type len)
         : ptr_(str), len_(len) {}
 
+      BOOST_CONSTEXPR basic_string_view(const charT* begin, const charT* end)
+        : ptr_(begin), len_(end - begin) {}
+
         // iterators
         BOOST_CONSTEXPR const_iterator   begin() const BOOST_NOEXCEPT { return ptr_; }
         BOOST_CONSTEXPR const_iterator  cbegin() const BOOST_NOEXCEPT { return ptr_; }

--- a/test/string_view_constexpr_test1.cpp
+++ b/test/string_view_constexpr_test1.cpp
@@ -76,11 +76,13 @@ int main()
     constexpr string_view sv1;
     constexpr string_view sv2{"abc", 3}; // ptr, len
     constexpr string_view sv3{"def"}; 	 // ptr
+    constexpr string_view sv4{sv3.begin(), sv3.end()}; // begin, end
 
 	constexpr const char *s1 = "";
 	constexpr const char *s2 = "abc";
 	
 	static_assert( (sv1 == sv1), "" );
+	static_assert( (sv3 == sv4), "" );
 	
 	static_assert(!(sv1 == sv2), "" );    
 	static_assert( (sv1 != sv2), "" );    

--- a/test/string_view_test1.cpp
+++ b/test/string_view_test1.cpp
@@ -29,15 +29,24 @@ void interop ( const std::string &str, string_view ref ) {
 void null_tests ( const char *p ) {
 //  All zero-length string-refs should be equal
     string_view sr1; // NULL, 0
-    string_view sr2 ( NULL, 0 );
-    string_view sr3 ( p, 0 );
+    string_view sr2 ( NULL, std::size_t(0) );
+    string_view sr3 ( p, std::size_t(0) );
     string_view sr4 ( p );
+    string_view sr5 ( p, p );
+    // string_view sr6 ( NULL, NULL ); // ambiguous
+#ifndef BOOST_NO_CXX11_NULLPTR
+    string_view sr6 ( nullptr, nullptr );
+#endif
     sr4.clear ();
 
     BOOST_TEST ( sr1 == sr2 );
     BOOST_TEST ( sr1 == sr3 );
     BOOST_TEST ( sr2 == sr3 );
     BOOST_TEST ( sr1 == sr4 );
+    BOOST_TEST ( sr1 == sr5 );
+#ifndef BOOST_NO_CXX11_NULLPTR
+    BOOST_TEST ( sr1 == sr6 );
+#endif
     }
 
 //  make sure that substrings work just like strings


### PR DESCRIPTION
With this commit, we can use boost::string_view with Boost.StringAlgo, such as `trim_copy` and `split`.