### PR TITLE
Add constexpr to operators (w/ basic docs, tests)

### DIFF
--- a/include/boost/operators.hpp
+++ b/include/boost/operators.hpp
@@ -132,34 +132,34 @@ template <typename T> class empty_base {};
 template <class T, class U, class B = operators_detail::empty_base<T> >
 struct less_than_comparable2 : B
 {
-     friend bool operator<=(const T& x, const U& y) { return !static_cast<bool>(x > y); }
-     friend bool operator>=(const T& x, const U& y) { return !static_cast<bool>(x < y); }
-     friend bool operator>(const U& x, const T& y)  { return y < x; }
-     friend bool operator<(const U& x, const T& y)  { return y > x; }
-     friend bool operator<=(const U& x, const T& y) { return !static_cast<bool>(y < x); }
-     friend bool operator>=(const U& x, const T& y) { return !static_cast<bool>(y > x); }
+     friend BOOST_CONSTEXPR bool operator<=(const T& x, const U& y) { return !static_cast<bool>(x > y); }
+     friend BOOST_CONSTEXPR bool operator>=(const T& x, const U& y) { return !static_cast<bool>(x < y); }
+     friend BOOST_CONSTEXPR bool operator>(const U& x, const T& y)  { return y < x; }
+     friend BOOST_CONSTEXPR bool operator<(const U& x, const T& y)  { return y > x; }
+     friend BOOST_CONSTEXPR bool operator<=(const U& x, const T& y) { return !static_cast<bool>(y < x); }
+     friend BOOST_CONSTEXPR bool operator>=(const U& x, const T& y) { return !static_cast<bool>(y > x); }
 };
 
 template <class T, class B = operators_detail::empty_base<T> >
 struct less_than_comparable1 : B
 {
-     friend bool operator>(const T& x, const T& y)  { return y < x; }
-     friend bool operator<=(const T& x, const T& y) { return !static_cast<bool>(y < x); }
-     friend bool operator>=(const T& x, const T& y) { return !static_cast<bool>(x < y); }
+     friend BOOST_CONSTEXPR bool operator>(const T& x, const T& y)  { return y < x; }
+     friend BOOST_CONSTEXPR bool operator<=(const T& x, const T& y) { return !static_cast<bool>(y < x); }
+     friend BOOST_CONSTEXPR bool operator>=(const T& x, const T& y) { return !static_cast<bool>(x < y); }
 };
 
 template <class T, class U, class B = operators_detail::empty_base<T> >
 struct equality_comparable2 : B
 {
-     friend bool operator==(const U& y, const T& x) { return x == y; }
-     friend bool operator!=(const U& y, const T& x) { return !static_cast<bool>(x == y); }
-     friend bool operator!=(const T& y, const U& x) { return !static_cast<bool>(y == x); }
+     friend BOOST_CONSTEXPR bool operator==(const U& y, const T& x) { return x == y; }
+     friend BOOST_CONSTEXPR bool operator!=(const U& y, const T& x) { return !static_cast<bool>(x == y); }
+     friend BOOST_CONSTEXPR bool operator!=(const T& y, const U& x) { return !static_cast<bool>(y == x); }
 };
 
 template <class T, class B = operators_detail::empty_base<T> >
 struct equality_comparable1 : B
 {
-     friend bool operator!=(const T& x, const T& y) { return !static_cast<bool>(x == y); }
+     friend BOOST_CONSTEXPR bool operator!=(const T& x, const T& y) { return !static_cast<bool>(x == y); }
 };
 
 // A macro which produces "name_2left" from "name".
@@ -174,43 +174,43 @@ struct equality_comparable1 : B
 // If the compiler has no NRVO, this is the best symmetric
 // implementation available.
 
-#define BOOST_BINARY_OPERATOR_COMMUTATIVE( NAME, OP )                   \
-template <class T, class U, class B = operators_detail::empty_base<T> > \
-struct NAME##2 : B                                                      \
-{                                                                       \
-  friend T operator OP( const T& lhs, const U& rhs )                    \
-    { T nrv( lhs ); nrv OP##= rhs; return nrv; }                        \
-  friend T operator OP( const U& lhs, const T& rhs )                    \
-    { T nrv( rhs ); nrv OP##= lhs; return nrv; }                        \
-};                                                                      \
-                                                                        \
-template <class T, class B = operators_detail::empty_base<T> >          \
-struct NAME##1 : B                                                      \
-{                                                                       \
-  friend T operator OP( const T& lhs, const T& rhs )                    \
-    { T nrv( lhs ); nrv OP##= rhs; return nrv; }                        \
+#define BOOST_BINARY_OPERATOR_COMMUTATIVE( NAME, OP )                      \
+template <class T, class U, class B = operators_detail::empty_base<T> >    \
+struct NAME##2 : B                                                         \
+{                                                                          \
+  friend BOOST_CXX14_CONSTEXPR T operator OP( const T& lhs, const U& rhs ) \
+    { T nrv( lhs ); nrv OP##= rhs; return nrv; }                           \
+  friend BOOST_CXX14_CONSTEXPR T operator OP( const U& lhs, const T& rhs ) \
+    { T nrv( rhs ); nrv OP##= lhs; return nrv; }                           \
+};                                                                         \
+                                                                           \
+template <class T, class B = operators_detail::empty_base<T> >             \
+struct NAME##1 : B                                                         \
+{                                                                          \
+  friend BOOST_CXX14_CONSTEXPR T operator OP( const T& lhs, const T& rhs ) \
+    { T nrv( lhs ); nrv OP##= rhs; return nrv; }                           \
 };
 
-#define BOOST_BINARY_OPERATOR_NON_COMMUTATIVE( NAME, OP )               \
-template <class T, class U, class B = operators_detail::empty_base<T> > \
-struct NAME##2 : B                                                      \
-{                                                                       \
-  friend T operator OP( const T& lhs, const U& rhs )                    \
-    { T nrv( lhs ); nrv OP##= rhs; return nrv; }                        \
-};                                                                      \
-                                                                        \
-template <class T, class U, class B = operators_detail::empty_base<T> > \
-struct BOOST_OPERATOR2_LEFT(NAME) : B                                   \
-{                                                                       \
-  friend T operator OP( const U& lhs, const T& rhs )                    \
-    { T nrv( lhs ); nrv OP##= rhs; return nrv; }                        \
-};                                                                      \
-                                                                        \
-template <class T, class B = operators_detail::empty_base<T> >          \
-struct NAME##1 : B                                                      \
-{                                                                       \
-  friend T operator OP( const T& lhs, const T& rhs )                    \
-    { T nrv( lhs ); nrv OP##= rhs; return nrv; }                        \
+#define BOOST_BINARY_OPERATOR_NON_COMMUTATIVE( NAME, OP )                  \
+template <class T, class U, class B = operators_detail::empty_base<T> >    \
+struct NAME##2 : B                                                         \
+{                                                                          \
+  friend BOOST_CXX14_CONSTEXPR T operator OP( const T& lhs, const U& rhs ) \
+    { T nrv( lhs ); nrv OP##= rhs; return nrv; }                           \
+};                                                                         \
+                                                                           \
+template <class T, class U, class B = operators_detail::empty_base<T> >    \
+struct BOOST_OPERATOR2_LEFT(NAME) : B                                      \
+{                                                                          \
+  friend BOOST_CXX14_CONSTEXPR T operator OP( const U& lhs, const T& rhs ) \
+    { T nrv( lhs ); nrv OP##= rhs; return nrv; }                           \
+};                                                                         \
+                                                                           \
+template <class T, class B = operators_detail::empty_base<T> >             \
+struct NAME##1 : B                                                         \
+{                                                                          \
+  friend BOOST_CXX14_CONSTEXPR T operator OP( const T& lhs, const T& rhs ) \
+    { T nrv( lhs ); nrv OP##= rhs; return nrv; }                           \
 };
 
 #else // defined(BOOST_HAS_NRVO) || defined(BOOST_FORCE_SYMMETRIC_OPERATORS)
@@ -220,38 +220,38 @@ struct NAME##1 : B                                                      \
 // BOOST_OPERATOR2_LEFT(NAME) only looks cool, but doesn't provide
 // optimization opportunities to the compiler :)
 
-#define BOOST_BINARY_OPERATOR_COMMUTATIVE( NAME, OP )                   \
-template <class T, class U, class B = operators_detail::empty_base<T> > \
-struct NAME##2 : B                                                      \
-{                                                                       \
-  friend T operator OP( T lhs, const U& rhs ) { return lhs OP##= rhs; } \
-  friend T operator OP( const U& lhs, T rhs ) { return rhs OP##= lhs; } \
-};                                                                      \
-                                                                        \
-template <class T, class B = operators_detail::empty_base<T> >          \
-struct NAME##1 : B                                                      \
-{                                                                       \
-  friend T operator OP( T lhs, const T& rhs ) { return lhs OP##= rhs; } \
+#define BOOST_BINARY_OPERATOR_COMMUTATIVE( NAME, OP )                                   \
+template <class T, class U, class B = operators_detail::empty_base<T> >                 \
+struct NAME##2 : B                                                                      \
+{                                                                                       \
+  friend BOOST_CONSTEXPR T operator OP( T lhs, const U& rhs ) { return lhs OP##= rhs; } \
+  friend BOOST_CONSTEXPR T operator OP( const U& lhs, T rhs ) { return rhs OP##= lhs; } \
+};                                                                                      \
+                                                                                        \
+template <class T, class B = operators_detail::empty_base<T> >                          \
+struct NAME##1 : B                                                                      \
+{                                                                                       \
+  friend BOOST_CONSTEXPR T operator OP( T lhs, const T& rhs ) { return lhs OP##= rhs; } \
 };
 
-#define BOOST_BINARY_OPERATOR_NON_COMMUTATIVE( NAME, OP )               \
-template <class T, class U, class B = operators_detail::empty_base<T> > \
-struct NAME##2 : B                                                      \
-{                                                                       \
-  friend T operator OP( T lhs, const U& rhs ) { return lhs OP##= rhs; } \
-};                                                                      \
-                                                                        \
-template <class T, class U, class B = operators_detail::empty_base<T> > \
-struct BOOST_OPERATOR2_LEFT(NAME) : B                                   \
-{                                                                       \
-  friend T operator OP( const U& lhs, const T& rhs )                    \
-    { return T( lhs ) OP##= rhs; }                                      \
-};                                                                      \
-                                                                        \
-template <class T, class B = operators_detail::empty_base<T> >          \
-struct NAME##1 : B                                                      \
-{                                                                       \
-  friend T operator OP( T lhs, const T& rhs ) { return lhs OP##= rhs; } \
+#define BOOST_BINARY_OPERATOR_NON_COMMUTATIVE( NAME, OP )                               \
+template <class T, class U, class B = operators_detail::empty_base<T> >                 \
+struct NAME##2 : B                                                                      \
+{                                                                                       \
+  friend BOOST_CONSTEXPR T operator OP( T lhs, const U& rhs ) { return lhs OP##= rhs; } \
+};                                                                                      \
+                                                                                        \
+template <class T, class U, class B = operators_detail::empty_base<T> >                 \
+struct BOOST_OPERATOR2_LEFT(NAME) : B                                                   \
+{                                                                                       \
+  friend BOOST_CONSTEXPR T operator OP( const U& lhs, const T& rhs )                    \
+    { return T( lhs ) OP##= rhs; }                                                      \
+};                                                                                      \
+                                                                                        \
+template <class T, class B = operators_detail::empty_base<T> >                          \
+struct NAME##1 : B                                                                      \
+{                                                                                       \
+  friend BOOST_CONSTEXPR T operator OP( T lhs, const T& rhs ) { return lhs OP##= rhs; } \
 };
 
 #endif // defined(BOOST_HAS_NRVO) || defined(BOOST_FORCE_SYMMETRIC_OPERATORS)
@@ -274,7 +274,7 @@ BOOST_BINARY_OPERATOR_COMMUTATIVE( orable, | )
 template <class T, class B = operators_detail::empty_base<T> >
 struct incrementable : B
 {
-  friend T operator++(T& x, int)
+  friend BOOST_CXX14_CONSTEXPR T operator++(T& x, int)
   {
     incrementable_type nrv(x);
     ++x;
@@ -287,7 +287,7 @@ private: // The use of this typedef works around a Borland bug
 template <class T, class B = operators_detail::empty_base<T> >
 struct decrementable : B
 {
-  friend T operator--(T& x, int)
+  friend BOOST_CXX14_CONSTEXPR T operator--(T& x, int)
   {
     decrementable_type nrv(x);
     --x;
@@ -322,34 +322,34 @@ struct indexable : B
 
 #if defined(BOOST_HAS_NRVO) || defined(BOOST_FORCE_SYMMETRIC_OPERATORS)
 
-#define BOOST_BINARY_OPERATOR( NAME, OP )                               \
-template <class T, class U, class B = operators_detail::empty_base<T> > \
-struct NAME##2 : B                                                      \
-{                                                                       \
-  friend T operator OP( const T& lhs, const U& rhs )                    \
-    { T nrv( lhs ); nrv OP##= rhs; return nrv; }                        \
-};                                                                      \
-                                                                        \
-template <class T, class B = operators_detail::empty_base<T> >          \
-struct NAME##1 : B                                                      \
-{                                                                       \
-  friend T operator OP( const T& lhs, const T& rhs )                    \
-    { T nrv( lhs ); nrv OP##= rhs; return nrv; }                        \
+#define BOOST_BINARY_OPERATOR( NAME, OP )                                  \
+template <class T, class U, class B = operators_detail::empty_base<T> >    \
+struct NAME##2 : B                                                         \
+{                                                                          \
+  friend BOOST_CXX14_CONSTEXPR T operator OP( const T& lhs, const U& rhs ) \
+    { T nrv( lhs ); nrv OP##= rhs; return nrv; }                           \
+};                                                                         \
+                                                                           \
+template <class T, class B = operators_detail::empty_base<T> >             \
+struct NAME##1 : B                                                         \
+{                                                                          \
+  friend BOOST_CXX14_CONSTEXPR T operator OP( const T& lhs, const T& rhs ) \
+    { T nrv( lhs ); nrv OP##= rhs; return nrv; }                           \
 };
 
 #else // defined(BOOST_HAS_NRVO) || defined(BOOST_FORCE_SYMMETRIC_OPERATORS)
 
-#define BOOST_BINARY_OPERATOR( NAME, OP )                               \
-template <class T, class U, class B = operators_detail::empty_base<T> > \
-struct NAME##2 : B                                                      \
-{                                                                       \
-  friend T operator OP( T lhs, const U& rhs ) { return lhs OP##= rhs; } \
-};                                                                      \
-                                                                        \
-template <class T, class B = operators_detail::empty_base<T> >          \
-struct NAME##1 : B                                                      \
-{                                                                       \
-  friend T operator OP( T lhs, const T& rhs ) { return lhs OP##= rhs; } \
+#define BOOST_BINARY_OPERATOR( NAME, OP )                                               \
+template <class T, class U, class B = operators_detail::empty_base<T> >                 \
+struct NAME##2 : B                                                                      \
+{                                                                                       \
+  friend BOOST_CONSTEXPR T operator OP( T lhs, const U& rhs ) { return lhs OP##= rhs; } \
+};                                                                                      \
+                                                                                        \
+template <class T, class B = operators_detail::empty_base<T> >                          \
+struct NAME##1 : B                                                                      \
+{                                                                                       \
+  friend BOOST_CONSTEXPR T operator OP( T lhs, const T& rhs ) { return lhs OP##= rhs; } \
 };
 
 #endif // defined(BOOST_HAS_NRVO) || defined(BOOST_FORCE_SYMMETRIC_OPERATORS)
@@ -362,7 +362,7 @@ BOOST_BINARY_OPERATOR( right_shiftable, >> )
 template <class T, class U, class B = operators_detail::empty_base<T> >
 struct equivalent2 : B
 {
-  friend bool operator==(const T& x, const U& y)
+  friend BOOST_CONSTEXPR bool operator==(const T& x, const U& y)
   {
     return !static_cast<bool>(x < y) && !static_cast<bool>(x > y);
   }
@@ -371,7 +371,7 @@ struct equivalent2 : B
 template <class T, class B = operators_detail::empty_base<T> >
 struct equivalent1 : B
 {
-  friend bool operator==(const T&x, const T&y)
+  friend BOOST_CONSTEXPR bool operator==(const T&x, const T&y)
   {
     return !static_cast<bool>(x < y) && !static_cast<bool>(y < x);
   }
@@ -380,28 +380,28 @@ struct equivalent1 : B
 template <class T, class U, class B = operators_detail::empty_base<T> >
 struct partially_ordered2 : B
 {
-  friend bool operator<=(const T& x, const U& y)
+  friend BOOST_CONSTEXPR bool operator<=(const T& x, const U& y)
     { return static_cast<bool>(x < y) || static_cast<bool>(x == y); }
-  friend bool operator>=(const T& x, const U& y)
+  friend BOOST_CONSTEXPR bool operator>=(const T& x, const U& y)
     { return static_cast<bool>(x > y) || static_cast<bool>(x == y); }
-  friend bool operator>(const U& x, const T& y)
+  friend BOOST_CONSTEXPR bool operator>(const U& x, const T& y)
     { return y < x; }
-  friend bool operator<(const U& x, const T& y)
+  friend BOOST_CONSTEXPR bool operator<(const U& x, const T& y)
     { return y > x; }
-  friend bool operator<=(const U& x, const T& y)
+  friend BOOST_CONSTEXPR bool operator<=(const U& x, const T& y)
     { return static_cast<bool>(y > x) || static_cast<bool>(y == x); }
-  friend bool operator>=(const U& x, const T& y)
+  friend BOOST_CONSTEXPR bool operator>=(const U& x, const T& y)
     { return static_cast<bool>(y < x) || static_cast<bool>(y == x); }
 };
 
 template <class T, class B = operators_detail::empty_base<T> >
 struct partially_ordered1 : B
 {
-  friend bool operator>(const T& x, const T& y)
+  friend BOOST_CONSTEXPR bool operator>(const T& x, const T& y)
     { return y < x; }
-  friend bool operator<=(const T& x, const T& y)
+  friend BOOST_CONSTEXPR bool operator<=(const T& x, const T& y)
     { return static_cast<bool>(x < y) || static_cast<bool>(x == y); }
-  friend bool operator>=(const T& x, const T& y)
+  friend BOOST_CONSTEXPR bool operator>=(const T& x, const T& y)
     { return static_cast<bool>(y < x) || static_cast<bool>(x == y); }
 };
 

--- a/include/boost/operators.hpp
+++ b/include/boost/operators.hpp
@@ -174,43 +174,43 @@ struct equality_comparable1 : B
 // If the compiler has no NRVO, this is the best symmetric
 // implementation available.
 
-#define BOOST_BINARY_OPERATOR_COMMUTATIVE( NAME, OP )                      \
-template <class T, class U, class B = operators_detail::empty_base<T> >    \
-struct NAME##2 : B                                                         \
-{                                                                          \
-  friend BOOST_CXX14_CONSTEXPR T operator OP( const T& lhs, const U& rhs ) \
-    { T nrv( lhs ); nrv OP##= rhs; return nrv; }                           \
-  friend BOOST_CXX14_CONSTEXPR T operator OP( const U& lhs, const T& rhs ) \
-    { T nrv( rhs ); nrv OP##= lhs; return nrv; }                           \
-};                                                                         \
-                                                                           \
-template <class T, class B = operators_detail::empty_base<T> >             \
-struct NAME##1 : B                                                         \
-{                                                                          \
-  friend BOOST_CXX14_CONSTEXPR T operator OP( const T& lhs, const T& rhs ) \
-    { T nrv( lhs ); nrv OP##= rhs; return nrv; }                           \
+#define BOOST_BINARY_OPERATOR_COMMUTATIVE( NAME, OP )                   \
+template <class T, class U, class B = operators_detail::empty_base<T> > \
+struct NAME##2 : B                                                      \
+{                                                                       \
+  friend T operator OP( const T& lhs, const U& rhs )                    \
+    { T nrv( lhs ); nrv OP##= rhs; return nrv; }                        \
+  friend T operator OP( const U& lhs, const T& rhs )                    \
+    { T nrv( rhs ); nrv OP##= lhs; return nrv; }                        \
+};                                                                      \
+                                                                        \
+template <class T, class B = operators_detail::empty_base<T> >          \
+struct NAME##1 : B                                                      \
+{                                                                       \
+  friend T operator OP( const T& lhs, const T& rhs )                    \
+    { T nrv( lhs ); nrv OP##= rhs; return nrv; }                        \
 };
 
-#define BOOST_BINARY_OPERATOR_NON_COMMUTATIVE( NAME, OP )                  \
-template <class T, class U, class B = operators_detail::empty_base<T> >    \
-struct NAME##2 : B                                                         \
-{                                                                          \
-  friend BOOST_CXX14_CONSTEXPR T operator OP( const T& lhs, const U& rhs ) \
-    { T nrv( lhs ); nrv OP##= rhs; return nrv; }                           \
-};                                                                         \
-                                                                           \
-template <class T, class U, class B = operators_detail::empty_base<T> >    \
-struct BOOST_OPERATOR2_LEFT(NAME) : B                                      \
-{                                                                          \
-  friend BOOST_CXX14_CONSTEXPR T operator OP( const U& lhs, const T& rhs ) \
-    { T nrv( lhs ); nrv OP##= rhs; return nrv; }                           \
-};                                                                         \
-                                                                           \
-template <class T, class B = operators_detail::empty_base<T> >             \
-struct NAME##1 : B                                                         \
-{                                                                          \
-  friend BOOST_CXX14_CONSTEXPR T operator OP( const T& lhs, const T& rhs ) \
-    { T nrv( lhs ); nrv OP##= rhs; return nrv; }                           \
+#define BOOST_BINARY_OPERATOR_NON_COMMUTATIVE( NAME, OP )               \
+template <class T, class U, class B = operators_detail::empty_base<T> > \
+struct NAME##2 : B                                                      \
+{                                                                       \
+  friend T operator OP( const T& lhs, const U& rhs )                    \
+    { T nrv( lhs ); nrv OP##= rhs; return nrv; }                        \
+};                                                                      \
+                                                                        \
+template <class T, class U, class B = operators_detail::empty_base<T> > \
+struct BOOST_OPERATOR2_LEFT(NAME) : B                                   \
+{                                                                       \
+  friend T operator OP( const U& lhs, const T& rhs )                    \
+    { T nrv( lhs ); nrv OP##= rhs; return nrv; }                        \
+};                                                                      \
+                                                                        \
+template <class T, class B = operators_detail::empty_base<T> >          \
+struct NAME##1 : B                                                      \
+{                                                                       \
+  friend T operator OP( const T& lhs, const T& rhs )                    \
+    { T nrv( lhs ); nrv OP##= rhs; return nrv; }                        \
 };
 
 #else // defined(BOOST_HAS_NRVO) || defined(BOOST_FORCE_SYMMETRIC_OPERATORS)
@@ -274,7 +274,7 @@ BOOST_BINARY_OPERATOR_COMMUTATIVE( orable, | )
 template <class T, class B = operators_detail::empty_base<T> >
 struct incrementable : B
 {
-  friend BOOST_CXX14_CONSTEXPR T operator++(T& x, int)
+  friend T operator++(T& x, int)
   {
     incrementable_type nrv(x);
     ++x;
@@ -287,7 +287,7 @@ private: // The use of this typedef works around a Borland bug
 template <class T, class B = operators_detail::empty_base<T> >
 struct decrementable : B
 {
-  friend BOOST_CXX14_CONSTEXPR T operator--(T& x, int)
+  friend T operator--(T& x, int)
   {
     decrementable_type nrv(x);
     --x;
@@ -322,19 +322,19 @@ struct indexable : B
 
 #if defined(BOOST_HAS_NRVO) || defined(BOOST_FORCE_SYMMETRIC_OPERATORS)
 
-#define BOOST_BINARY_OPERATOR( NAME, OP )                                  \
-template <class T, class U, class B = operators_detail::empty_base<T> >    \
-struct NAME##2 : B                                                         \
-{                                                                          \
-  friend BOOST_CXX14_CONSTEXPR T operator OP( const T& lhs, const U& rhs ) \
-    { T nrv( lhs ); nrv OP##= rhs; return nrv; }                           \
-};                                                                         \
-                                                                           \
-template <class T, class B = operators_detail::empty_base<T> >             \
-struct NAME##1 : B                                                         \
-{                                                                          \
-  friend BOOST_CXX14_CONSTEXPR T operator OP( const T& lhs, const T& rhs ) \
-    { T nrv( lhs ); nrv OP##= rhs; return nrv; }                           \
+#define BOOST_BINARY_OPERATOR( NAME, OP )                               \
+template <class T, class U, class B = operators_detail::empty_base<T> > \
+struct NAME##2 : B                                                      \
+{                                                                       \
+  friend T operator OP( const T& lhs, const U& rhs )                    \
+    { T nrv( lhs ); nrv OP##= rhs; return nrv; }                        \
+};                                                                      \
+                                                                        \
+template <class T, class B = operators_detail::empty_base<T> >          \
+struct NAME##1 : B                                                      \
+{                                                                       \
+  friend T operator OP( const T& lhs, const T& rhs )                    \
+    { T nrv( lhs ); nrv OP##= rhs; return nrv; }                        \
 };
 
 #else // defined(BOOST_HAS_NRVO) || defined(BOOST_FORCE_SYMMETRIC_OPERATORS)

--- a/include/boost/operators.hpp
+++ b/include/boost/operators.hpp
@@ -109,6 +109,13 @@
 #   pragma warning( disable : 4284 ) // complaint about return type of
 #endif                               // operator-> not begin a UDT
 
+// Define BOOST_OPS_CONSTEXPR to be like BOOST_CONSTEXPR but empty under MSVC
+#ifdef BOOST_MSVC
+#define BOOST_OPS_CONSTEXPR
+#else
+#define BOOST_OPS_CONSTEXPR BOOST_CONSTEXPR
+#endif
+
 // In this section we supply the xxxx1 and xxxx2 forms of the operator
 // templates, which are explicitly targeted at the 1-type-argument and
 // 2-type-argument operator forms, respectively.
@@ -132,34 +139,34 @@ template <typename T> class empty_base {};
 template <class T, class U, class B = operators_detail::empty_base<T> >
 struct less_than_comparable2 : B
 {
-     friend BOOST_CONSTEXPR bool operator<=(const T& x, const U& y) { return !static_cast<bool>(x > y); }
-     friend BOOST_CONSTEXPR bool operator>=(const T& x, const U& y) { return !static_cast<bool>(x < y); }
-     friend BOOST_CONSTEXPR bool operator>(const U& x, const T& y)  { return y < x; }
-     friend BOOST_CONSTEXPR bool operator<(const U& x, const T& y)  { return y > x; }
-     friend BOOST_CONSTEXPR bool operator<=(const U& x, const T& y) { return !static_cast<bool>(y < x); }
-     friend BOOST_CONSTEXPR bool operator>=(const U& x, const T& y) { return !static_cast<bool>(y > x); }
+     friend BOOST_OPS_CONSTEXPR bool operator<=(const T& x, const U& y) { return !static_cast<bool>(x > y); }
+     friend BOOST_OPS_CONSTEXPR bool operator>=(const T& x, const U& y) { return !static_cast<bool>(x < y); }
+     friend BOOST_OPS_CONSTEXPR bool operator>(const U& x, const T& y)  { return y < x; }
+     friend BOOST_OPS_CONSTEXPR bool operator<(const U& x, const T& y)  { return y > x; }
+     friend BOOST_OPS_CONSTEXPR bool operator<=(const U& x, const T& y) { return !static_cast<bool>(y < x); }
+     friend BOOST_OPS_CONSTEXPR bool operator>=(const U& x, const T& y) { return !static_cast<bool>(y > x); }
 };
 
 template <class T, class B = operators_detail::empty_base<T> >
 struct less_than_comparable1 : B
 {
-     friend BOOST_CONSTEXPR bool operator>(const T& x, const T& y)  { return y < x; }
-     friend BOOST_CONSTEXPR bool operator<=(const T& x, const T& y) { return !static_cast<bool>(y < x); }
-     friend BOOST_CONSTEXPR bool operator>=(const T& x, const T& y) { return !static_cast<bool>(x < y); }
+     friend BOOST_OPS_CONSTEXPR bool operator>(const T& x, const T& y)  { return y < x; }
+     friend BOOST_OPS_CONSTEXPR bool operator<=(const T& x, const T& y) { return !static_cast<bool>(y < x); }
+     friend BOOST_OPS_CONSTEXPR bool operator>=(const T& x, const T& y) { return !static_cast<bool>(x < y); }
 };
 
 template <class T, class U, class B = operators_detail::empty_base<T> >
 struct equality_comparable2 : B
 {
-     friend BOOST_CONSTEXPR bool operator==(const U& y, const T& x) { return x == y; }
-     friend BOOST_CONSTEXPR bool operator!=(const U& y, const T& x) { return !static_cast<bool>(x == y); }
-     friend BOOST_CONSTEXPR bool operator!=(const T& y, const U& x) { return !static_cast<bool>(y == x); }
+     friend BOOST_OPS_CONSTEXPR bool operator==(const U& y, const T& x) { return x == y; }
+     friend BOOST_OPS_CONSTEXPR bool operator!=(const U& y, const T& x) { return !static_cast<bool>(x == y); }
+     friend BOOST_OPS_CONSTEXPR bool operator!=(const T& y, const U& x) { return !static_cast<bool>(y == x); }
 };
 
 template <class T, class B = operators_detail::empty_base<T> >
 struct equality_comparable1 : B
 {
-     friend BOOST_CONSTEXPR bool operator!=(const T& x, const T& y) { return !static_cast<bool>(x == y); }
+     friend BOOST_OPS_CONSTEXPR bool operator!=(const T& x, const T& y) { return !static_cast<bool>(x == y); }
 };
 
 // A macro which produces "name_2left" from "name".
@@ -220,38 +227,38 @@ struct NAME##1 : B                                                      \
 // BOOST_OPERATOR2_LEFT(NAME) only looks cool, but doesn't provide
 // optimization opportunities to the compiler :)
 
-#define BOOST_BINARY_OPERATOR_COMMUTATIVE( NAME, OP )                                   \
-template <class T, class U, class B = operators_detail::empty_base<T> >                 \
-struct NAME##2 : B                                                                      \
-{                                                                                       \
-  friend BOOST_CONSTEXPR T operator OP( T lhs, const U& rhs ) { return lhs OP##= rhs; } \
-  friend BOOST_CONSTEXPR T operator OP( const U& lhs, T rhs ) { return rhs OP##= lhs; } \
-};                                                                                      \
-                                                                                        \
-template <class T, class B = operators_detail::empty_base<T> >                          \
-struct NAME##1 : B                                                                      \
-{                                                                                       \
-  friend BOOST_CONSTEXPR T operator OP( T lhs, const T& rhs ) { return lhs OP##= rhs; } \
+#define BOOST_BINARY_OPERATOR_COMMUTATIVE( NAME, OP )                                       \
+template <class T, class U, class B = operators_detail::empty_base<T> >                     \
+struct NAME##2 : B                                                                          \
+{                                                                                           \
+  friend BOOST_OPS_CONSTEXPR T operator OP( T lhs, const U& rhs ) { return lhs OP##= rhs; } \
+  friend BOOST_OPS_CONSTEXPR T operator OP( const U& lhs, T rhs ) { return rhs OP##= lhs; } \
+};                                                                                          \
+                                                                                            \
+template <class T, class B = operators_detail::empty_base<T> >                              \
+struct NAME##1 : B                                                                          \
+{                                                                                           \
+  friend BOOST_OPS_CONSTEXPR T operator OP( T lhs, const T& rhs ) { return lhs OP##= rhs; } \
 };
 
-#define BOOST_BINARY_OPERATOR_NON_COMMUTATIVE( NAME, OP )                               \
-template <class T, class U, class B = operators_detail::empty_base<T> >                 \
-struct NAME##2 : B                                                                      \
-{                                                                                       \
-  friend BOOST_CONSTEXPR T operator OP( T lhs, const U& rhs ) { return lhs OP##= rhs; } \
-};                                                                                      \
-                                                                                        \
-template <class T, class U, class B = operators_detail::empty_base<T> >                 \
-struct BOOST_OPERATOR2_LEFT(NAME) : B                                                   \
-{                                                                                       \
-  friend BOOST_CONSTEXPR T operator OP( const U& lhs, const T& rhs )                    \
-    { return T( lhs ) OP##= rhs; }                                                      \
-};                                                                                      \
-                                                                                        \
-template <class T, class B = operators_detail::empty_base<T> >                          \
-struct NAME##1 : B                                                                      \
-{                                                                                       \
-  friend BOOST_CONSTEXPR T operator OP( T lhs, const T& rhs ) { return lhs OP##= rhs; } \
+#define BOOST_BINARY_OPERATOR_NON_COMMUTATIVE( NAME, OP )                                   \
+template <class T, class U, class B = operators_detail::empty_base<T> >                     \
+struct NAME##2 : B                                                                          \
+{                                                                                           \
+  friend BOOST_OPS_CONSTEXPR T operator OP( T lhs, const U& rhs ) { return lhs OP##= rhs; } \
+};                                                                                          \
+                                                                                            \
+template <class T, class U, class B = operators_detail::empty_base<T> >                     \
+struct BOOST_OPERATOR2_LEFT(NAME) : B                                                       \
+{                                                                                           \
+  friend BOOST_OPS_CONSTEXPR T operator OP( const U& lhs, const T& rhs )                    \
+    { return T( lhs ) OP##= rhs; }                                                          \
+};                                                                                          \
+                                                                                            \
+template <class T, class B = operators_detail::empty_base<T> >                              \
+struct NAME##1 : B                                                                          \
+{                                                                                           \
+  friend BOOST_OPS_CONSTEXPR T operator OP( T lhs, const T& rhs ) { return lhs OP##= rhs; } \
 };
 
 #endif // defined(BOOST_HAS_NRVO) || defined(BOOST_FORCE_SYMMETRIC_OPERATORS)
@@ -343,13 +350,13 @@ struct NAME##1 : B                                                      \
 template <class T, class U, class B = operators_detail::empty_base<T> >                 \
 struct NAME##2 : B                                                                      \
 {                                                                                       \
-  friend BOOST_CONSTEXPR T operator OP( T lhs, const U& rhs ) { return lhs OP##= rhs; } \
+  friend BOOST_OPS_CONSTEXPR T operator OP( T lhs, const U& rhs ) { return lhs OP##= rhs; } \
 };                                                                                      \
                                                                                         \
 template <class T, class B = operators_detail::empty_base<T> >                          \
 struct NAME##1 : B                                                                      \
 {                                                                                       \
-  friend BOOST_CONSTEXPR T operator OP( T lhs, const T& rhs ) { return lhs OP##= rhs; } \
+  friend BOOST_OPS_CONSTEXPR T operator OP( T lhs, const T& rhs ) { return lhs OP##= rhs; } \
 };
 
 #endif // defined(BOOST_HAS_NRVO) || defined(BOOST_FORCE_SYMMETRIC_OPERATORS)
@@ -362,7 +369,7 @@ BOOST_BINARY_OPERATOR( right_shiftable, >> )
 template <class T, class U, class B = operators_detail::empty_base<T> >
 struct equivalent2 : B
 {
-  friend BOOST_CONSTEXPR bool operator==(const T& x, const U& y)
+  friend BOOST_OPS_CONSTEXPR bool operator==(const T& x, const U& y)
   {
     return !static_cast<bool>(x < y) && !static_cast<bool>(x > y);
   }
@@ -371,7 +378,7 @@ struct equivalent2 : B
 template <class T, class B = operators_detail::empty_base<T> >
 struct equivalent1 : B
 {
-  friend BOOST_CONSTEXPR bool operator==(const T&x, const T&y)
+  friend BOOST_OPS_CONSTEXPR bool operator==(const T&x, const T&y)
   {
     return !static_cast<bool>(x < y) && !static_cast<bool>(y < x);
   }
@@ -380,28 +387,28 @@ struct equivalent1 : B
 template <class T, class U, class B = operators_detail::empty_base<T> >
 struct partially_ordered2 : B
 {
-  friend BOOST_CONSTEXPR bool operator<=(const T& x, const U& y)
+  friend BOOST_OPS_CONSTEXPR bool operator<=(const T& x, const U& y)
     { return static_cast<bool>(x < y) || static_cast<bool>(x == y); }
-  friend BOOST_CONSTEXPR bool operator>=(const T& x, const U& y)
+  friend BOOST_OPS_CONSTEXPR bool operator>=(const T& x, const U& y)
     { return static_cast<bool>(x > y) || static_cast<bool>(x == y); }
-  friend BOOST_CONSTEXPR bool operator>(const U& x, const T& y)
+  friend BOOST_OPS_CONSTEXPR bool operator>(const U& x, const T& y)
     { return y < x; }
-  friend BOOST_CONSTEXPR bool operator<(const U& x, const T& y)
+  friend BOOST_OPS_CONSTEXPR bool operator<(const U& x, const T& y)
     { return y > x; }
-  friend BOOST_CONSTEXPR bool operator<=(const U& x, const T& y)
+  friend BOOST_OPS_CONSTEXPR bool operator<=(const U& x, const T& y)
     { return static_cast<bool>(y > x) || static_cast<bool>(y == x); }
-  friend BOOST_CONSTEXPR bool operator>=(const U& x, const T& y)
+  friend BOOST_OPS_CONSTEXPR bool operator>=(const U& x, const T& y)
     { return static_cast<bool>(y < x) || static_cast<bool>(y == x); }
 };
 
 template <class T, class B = operators_detail::empty_base<T> >
 struct partially_ordered1 : B
 {
-  friend BOOST_CONSTEXPR bool operator>(const T& x, const T& y)
+  friend BOOST_OPS_CONSTEXPR bool operator>(const T& x, const T& y)
     { return y < x; }
-  friend BOOST_CONSTEXPR bool operator<=(const T& x, const T& y)
+  friend BOOST_OPS_CONSTEXPR bool operator<=(const T& x, const T& y)
     { return static_cast<bool>(x < y) || static_cast<bool>(x == y); }
-  friend BOOST_CONSTEXPR bool operator>=(const T& x, const T& y)
+  friend BOOST_OPS_CONSTEXPR bool operator>=(const T& x, const T& y)
     { return static_cast<bool>(y < x) || static_cast<bool>(x == y); }
 };
 

--- a/include/boost/operators.hpp
+++ b/include/boost/operators.hpp
@@ -109,9 +109,13 @@
 #   pragma warning( disable : 4284 ) // complaint about return type of
 #endif                               // operator-> not begin a UDT
 
-// Define BOOST_OPS_CONSTEXPR to be like BOOST_CONSTEXPR but empty under MSVC
+// Define BOOST_OPS_CONSTEXPR to be like BOOST_CONSTEXPR but empty under MSVC < v19.22
 #ifdef BOOST_MSVC
+#if BOOST_MSVC_FULL_VER >= 192200000
+#define BOOST_OPS_CONSTEXPR constexpr
+#else
 #define BOOST_OPS_CONSTEXPR
+#endif
 #else
 #define BOOST_OPS_CONSTEXPR BOOST_CONSTEXPR
 #endif

--- a/include/boost/operators.hpp
+++ b/include/boost/operators.hpp
@@ -231,38 +231,38 @@ struct NAME##1 : B                                                      \
 // BOOST_OPERATOR2_LEFT(NAME) only looks cool, but doesn't provide
 // optimization opportunities to the compiler :)
 
-#define BOOST_BINARY_OPERATOR_COMMUTATIVE( NAME, OP )                                       \
-template <class T, class U, class B = operators_detail::empty_base<T> >                     \
-struct NAME##2 : B                                                                          \
-{                                                                                           \
-  friend BOOST_OPS_CONSTEXPR T operator OP( T lhs, const U& rhs ) { return lhs OP##= rhs; } \
-  friend BOOST_OPS_CONSTEXPR T operator OP( const U& lhs, T rhs ) { return rhs OP##= lhs; } \
-};                                                                                          \
-                                                                                            \
-template <class T, class B = operators_detail::empty_base<T> >                              \
-struct NAME##1 : B                                                                          \
-{                                                                                           \
-  friend BOOST_OPS_CONSTEXPR T operator OP( T lhs, const T& rhs ) { return lhs OP##= rhs; } \
+#define BOOST_BINARY_OPERATOR_COMMUTATIVE( NAME, OP )                   \
+template <class T, class U, class B = operators_detail::empty_base<T> > \
+struct NAME##2 : B                                                      \
+{                                                                       \
+  friend T operator OP( T lhs, const U& rhs ) { return lhs OP##= rhs; } \
+  friend T operator OP( const U& lhs, T rhs ) { return rhs OP##= lhs; } \
+};                                                                      \
+                                                                        \
+template <class T, class B = operators_detail::empty_base<T> >          \
+struct NAME##1 : B                                                      \
+{                                                                       \
+  friend T operator OP( T lhs, const T& rhs ) { return lhs OP##= rhs; } \
 };
 
-#define BOOST_BINARY_OPERATOR_NON_COMMUTATIVE( NAME, OP )                                   \
-template <class T, class U, class B = operators_detail::empty_base<T> >                     \
-struct NAME##2 : B                                                                          \
-{                                                                                           \
-  friend BOOST_OPS_CONSTEXPR T operator OP( T lhs, const U& rhs ) { return lhs OP##= rhs; } \
-};                                                                                          \
-                                                                                            \
-template <class T, class U, class B = operators_detail::empty_base<T> >                     \
-struct BOOST_OPERATOR2_LEFT(NAME) : B                                                       \
-{                                                                                           \
-  friend BOOST_OPS_CONSTEXPR T operator OP( const U& lhs, const T& rhs )                    \
-    { return T( lhs ) OP##= rhs; }                                                          \
-};                                                                                          \
-                                                                                            \
-template <class T, class B = operators_detail::empty_base<T> >                              \
-struct NAME##1 : B                                                                          \
-{                                                                                           \
-  friend BOOST_OPS_CONSTEXPR T operator OP( T lhs, const T& rhs ) { return lhs OP##= rhs; } \
+#define BOOST_BINARY_OPERATOR_NON_COMMUTATIVE( NAME, OP )               \
+template <class T, class U, class B = operators_detail::empty_base<T> > \
+struct NAME##2 : B                                                      \
+{                                                                       \
+  friend T operator OP( T lhs, const U& rhs ) { return lhs OP##= rhs; } \
+};                                                                      \
+                                                                        \
+template <class T, class U, class B = operators_detail::empty_base<T> > \
+struct BOOST_OPERATOR2_LEFT(NAME) : B                                   \
+{                                                                       \
+  friend T operator OP( const U& lhs, const T& rhs )                    \
+    { return T( lhs ) OP##= rhs; }                                      \
+};                                                                      \
+                                                                        \
+template <class T, class B = operators_detail::empty_base<T> >          \
+struct NAME##1 : B                                                      \
+{                                                                       \
+  friend T operator OP( T lhs, const T& rhs ) { return lhs OP##= rhs; } \
 };
 
 #endif // defined(BOOST_HAS_NRVO) || defined(BOOST_FORCE_SYMMETRIC_OPERATORS)
@@ -350,17 +350,17 @@ struct NAME##1 : B                                                      \
 
 #else // defined(BOOST_HAS_NRVO) || defined(BOOST_FORCE_SYMMETRIC_OPERATORS)
 
-#define BOOST_BINARY_OPERATOR( NAME, OP )                                               \
-template <class T, class U, class B = operators_detail::empty_base<T> >                 \
-struct NAME##2 : B                                                                      \
-{                                                                                       \
-  friend BOOST_OPS_CONSTEXPR T operator OP( T lhs, const U& rhs ) { return lhs OP##= rhs; } \
-};                                                                                      \
-                                                                                        \
-template <class T, class B = operators_detail::empty_base<T> >                          \
-struct NAME##1 : B                                                                      \
-{                                                                                       \
-  friend BOOST_OPS_CONSTEXPR T operator OP( T lhs, const T& rhs ) { return lhs OP##= rhs; } \
+#define BOOST_BINARY_OPERATOR( NAME, OP )                               \
+template <class T, class U, class B = operators_detail::empty_base<T> > \
+struct NAME##2 : B                                                      \
+{                                                                       \
+  friend T operator OP( T lhs, const U& rhs ) { return lhs OP##= rhs; } \
+};                                                                      \
+                                                                        \
+template <class T, class B = operators_detail::empty_base<T> >          \
+struct NAME##1 : B                                                      \
+{                                                                       \
+  friend T operator OP( T lhs, const T& rhs ) { return lhs OP##= rhs; } \
 };
 
 #endif // defined(BOOST_HAS_NRVO) || defined(BOOST_FORCE_SYMMETRIC_OPERATORS)

--- a/operators.htm
+++ b/operators.htm
@@ -500,7 +500,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         "#ordering">Ordering Note</a>.</td>
 
         <td>Since <code>C++11</code><br>
-        <span style="font-size:small;">(except <a href="https://developercommunity.visualstudio.com/content/problem/414193/rejects-valid-constexpr-marked-friend-function-def.html">MSVC</a>)</span></td>
+        <span style="font-size:small;">(except <a href="https://developercommunity.visualstudio.com/content/problem/414193/rejects-valid-constexpr-marked-friend-function-def.html">MSVC &lt; v19.22</a>)</span></td>
       </tr>
 
       <tr>
@@ -520,7 +520,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         "#ordering">Ordering Note</a>.</td>
 
         <td>Since <code>C++11</code><br>
-        <span style="font-size:small;">(except <a href="https://developercommunity.visualstudio.com/content/problem/414193/rejects-valid-constexpr-marked-friend-function-def.html">MSVC</a>)</span></td>
+        <span style="font-size:small;">(except <a href="https://developercommunity.visualstudio.com/content/problem/414193/rejects-valid-constexpr-marked-friend-function-def.html">MSVC &lt; v19.22</a>)</span></td>
       </tr>
 
       <tr>
@@ -534,7 +534,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
          Return convertible to <code>bool</code>.</td>
 
         <td>Since <code>C++11</code><br>
-        <span style="font-size:small;">(except <a href="https://developercommunity.visualstudio.com/content/problem/414193/rejects-valid-constexpr-marked-friend-function-def.html">MSVC</a>)</span></td>
+        <span style="font-size:small;">(except <a href="https://developercommunity.visualstudio.com/content/problem/414193/rejects-valid-constexpr-marked-friend-function-def.html">MSVC &lt; v19.22</a>)</span></td>
       </tr>
 
       <tr>
@@ -550,7 +550,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
          Return convertible to <code>bool</code>.</td>
 
          <td>Since <code>C++11</code><br>
-        <span style="font-size:small;">(except <a href="https://developercommunity.visualstudio.com/content/problem/414193/rejects-valid-constexpr-marked-friend-function-def.html">MSVC</a>)</span></td>
+        <span style="font-size:small;">(except <a href="https://developercommunity.visualstudio.com/content/problem/414193/rejects-valid-constexpr-marked-friend-function-def.html">MSVC &lt; v19.22</a>)</span></td>
       </tr>
 
       <tr>
@@ -897,7 +897,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         "#ordering">Ordering Note</a>.</td>
 
         <td>Since <code>C++11</code><br>
-        <span style="font-size:small;">(except <a href="https://developercommunity.visualstudio.com/content/problem/414193/rejects-valid-constexpr-marked-friend-function-def.html">MSVC</a>)</span></td>
+        <span style="font-size:small;">(except <a href="https://developercommunity.visualstudio.com/content/problem/414193/rejects-valid-constexpr-marked-friend-function-def.html">MSVC &lt; v19.22</a>)</span></td>
       </tr>
 
       <tr>
@@ -911,7 +911,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         "#ordering">Ordering Note</a>.</td>
 
         <td>Since <code>C++11</code><br>
-        <span style="font-size:small;">(except <a href="https://developercommunity.visualstudio.com/content/problem/414193/rejects-valid-constexpr-marked-friend-function-def.html">MSVC</a>)</span></td>
+        <span style="font-size:small;">(except <a href="https://developercommunity.visualstudio.com/content/problem/414193/rejects-valid-constexpr-marked-friend-function-def.html">MSVC &lt; v19.22</a>)</span></td>
       </tr>
 
       <tr>
@@ -928,7 +928,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         "#ordering">Ordering Note</a>.</td>
 
         <td>Since <code>C++11</code><br>
-        <span style="font-size:small;">(except <a href="https://developercommunity.visualstudio.com/content/problem/414193/rejects-valid-constexpr-marked-friend-function-def.html">MSVC</a>)</span></td>
+        <span style="font-size:small;">(except <a href="https://developercommunity.visualstudio.com/content/problem/414193/rejects-valid-constexpr-marked-friend-function-def.html">MSVC &lt; v19.22</a>)</span></td>
       </tr>
 
       <tr>
@@ -949,7 +949,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         "#ordering">Ordering Note</a>.</td>
 
         <td>Since <code>C++11</code><br>
-        <span style="font-size:small;">(except <a href="https://developercommunity.visualstudio.com/content/problem/414193/rejects-valid-constexpr-marked-friend-function-def.html">MSVC</a>)</span></td>
+        <span style="font-size:small;">(except <a href="https://developercommunity.visualstudio.com/content/problem/414193/rejects-valid-constexpr-marked-friend-function-def.html">MSVC &lt; v19.22</a>)</span></td>
       </tr>
     </table>
 

--- a/operators.htm
+++ b/operators.htm
@@ -454,7 +454,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
       </caption>
 
       <tr>
-        <td colspan="3">
+        <td colspan="4">
           <table align="center" border="1">
             <caption>
               <em>Key</em>
@@ -482,6 +482,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <th>Supplied Operations</th>
 
         <th>Requirements</th>
+
+        <th>Propagates <code>constexpr</code>?</th>
       </tr>
 
       <tr>
@@ -496,6 +498,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>t &lt; t1</code>.<br>
          Return convertible to <code>bool</code>. See the <a href=
         "#ordering">Ordering Note</a>.</td>
+
+        <td>Since <code>C++11</code></td>
       </tr>
 
       <tr>
@@ -513,6 +517,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>t &lt; u</code>. <code>t &gt; u</code>.<br>
          Returns convertible to <code>bool</code>. See the <a href=
         "#ordering">Ordering Note</a>.</td>
+
+        <td>Since <code>C++11</code></td>
       </tr>
 
       <tr>
@@ -524,6 +530,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
 
         <td><code>t == t1</code>.<br>
          Return convertible to <code>bool</code>.</td>
+
+        <td>Since <code>C++11</code></td>
       </tr>
 
       <tr>
@@ -537,6 +545,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
 
         <td><code>t == u</code>.<br>
          Return convertible to <code>bool</code>.</td>
+
+         <td>Since <code>C++11</code></td>
       </tr>
 
       <tr>
@@ -548,6 +558,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>T temp(t); temp += t1</code>.<br>
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
+
+        <td>Since <code>C++14</code></td>
       </tr>
 
       <tr>
@@ -560,6 +572,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>T temp(t); temp += u</code>.<br>
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
+
+        <td>Since <code>C++14</code></td>
       </tr>
 
       <tr>
@@ -572,6 +586,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>T temp(t); temp -= t1</code>.<br>
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
+
+        <td>Since <code>C++14</code></td>
       </tr>
 
       <tr>
@@ -584,6 +600,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>T temp(t); temp -= u</code>.<br>
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
+
+        <td>Since <code>C++14</code></td>
       </tr>
 
       <tr>
@@ -594,6 +612,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
 
         <td><code>T temp(u); temp -= t</code>.<br>
          Return convertible to <code>T</code>.</td>
+
+         <td>Since <code>C++14</code></td>
       </tr>
 
       <tr>
@@ -606,6 +626,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>T temp(t); temp *= t1</code>.<br>
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
+
+        <td>Since <code>C++14</code></td>
       </tr>
 
       <tr>
@@ -619,6 +641,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>T temp(t); temp *= u</code>.<br>
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
+
+        <td>Since <code>C++14</code></td>
       </tr>
 
       <tr>
@@ -630,6 +654,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>T temp(t); temp /= t1</code>.<br>
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
+
+        <td>Since <code>C++14</code></td>
       </tr>
 
       <tr>
@@ -641,6 +667,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>T temp(t); temp /= u</code>.<br>
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
+
+        <td>Since <code>C++14</code></td>
       </tr>
 
       <tr>
@@ -651,6 +679,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
 
         <td><code>T temp(u); temp /= t</code>.<br>
          Return convertible to <code>T</code>.</td>
+
+         <td>Since <code>C++14</code></td>
       </tr>
 
       <tr>
@@ -662,6 +692,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>T temp(t); temp %= t1</code>.<br>
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
+
+        <td>Since <code>C++14</code></td>
       </tr>
 
       <tr>
@@ -673,6 +705,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>T temp(t); temp %= u</code>.<br>
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
+
+        <td>Since <code>C++14</code></td>
       </tr>
 
       <tr>
@@ -683,6 +717,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
 
         <td><code>T temp(u); temp %= t</code>.<br>
          Return convertible to <code>T</code>.</td>
+
+         <td>Since <code>C++14</code></td>
       </tr>
 
       <tr>
@@ -694,6 +730,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>T temp(t); temp |= t1</code>.<br>
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
+
+        <td>Since <code>C++14</code></td>
       </tr>
 
       <tr>
@@ -706,6 +744,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>T temp(t); temp |= u</code>.<br>
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
+
+        <td>Since <code>C++14</code></td>
       </tr>
 
       <tr>
@@ -717,6 +757,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>T temp(t); temp &amp;= t1</code>.<br>
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
+
+        <td>Since <code>C++14</code></td>
       </tr>
 
       <tr>
@@ -729,6 +771,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>T temp(t); temp &amp;= u</code>.<br>
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
+
+        <td>Since <code>C++14</code></td>
       </tr>
 
       <tr>
@@ -740,6 +784,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>T temp(t); temp ^= t1</code>.<br>
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
+
+        <td>Since <code>C++14</code></td>
       </tr>
 
       <tr>
@@ -752,6 +798,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>T temp(t); temp ^= u</code>.<br>
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
+
+        <td>Since <code>C++14</code></td>
       </tr>
 
       <tr>
@@ -762,6 +810,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
 
         <td><code>T temp(t); ++t</code><br>
          Return convertible to <code>T</code>.</td>
+
+         <td>Since <code>C++14</code></td>
       </tr>
 
       <tr>
@@ -772,6 +822,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
 
         <td><code>T temp(t); --t;</code><br>
          Return convertible to <code>T</code>.</td>
+
+         <td>Since <code>C++14</code></td>
       </tr>
 
       <tr>
@@ -784,6 +836,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>T temp(t); temp &lt;&lt;= t1</code>.<br>
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
+
+        <td>Since <code>C++14</code></td>
       </tr>
 
       <tr>
@@ -796,6 +850,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>T temp(t); temp &lt;&lt;= u</code>.<br>
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
+
+        <td>Since <code>C++14</code></td>
       </tr>
 
       <tr>
@@ -808,6 +864,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>T temp(t); temp &gt;&gt;= t1</code>.<br>
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
+
+        <td>Since <code>C++14</code></td>
       </tr>
 
       <tr>
@@ -820,6 +878,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>T temp(t); temp &gt;&gt;= u</code>.<br>
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
+
+        <td>Since <code>C++14</code></td>
       </tr>
 
       <tr>
@@ -831,6 +891,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>t &lt; t1</code>.<br>
          Return convertible to <code>bool</code>. See the <a href=
         "#ordering">Ordering Note</a>.</td>
+
+        <td>Since <code>C++11</code></td>
       </tr>
 
       <tr>
@@ -842,6 +904,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>t &lt; u</code>. <code>t &gt; u</code>.<br>
          Returns convertible to <code>bool</code>. See the <a href=
         "#ordering">Ordering Note</a>.</td>
+
+        <td>Since <code>C++11</code></td>
       </tr>
 
       <tr>
@@ -856,6 +920,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>t &lt; t1</code>. <code>t == t1</code>.<br>
          Returns convertible to <code>bool</code>. See the <a href=
         "#ordering">Ordering Note</a>.</td>
+
+        <td>Since <code>C++11</code></td>
       </tr>
 
       <tr>
@@ -874,6 +940,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         u</code>.<br>
          Returns convertible to <code>bool</code>. See the <a href=
         "#ordering">Ordering Note</a>.</td>
+
+        <td>Since <code>C++11</code></td>
       </tr>
     </table>
 

--- a/operators.htm
+++ b/operators.htm
@@ -559,7 +559,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
 
-        <td>Since <code>C++14</code></td>
+        <td>No</td>
       </tr>
 
       <tr>
@@ -573,7 +573,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
 
-        <td>Since <code>C++14</code></td>
+        <td>No</td>
       </tr>
 
       <tr>
@@ -587,7 +587,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
 
-        <td>Since <code>C++14</code></td>
+        <td>No</td>
       </tr>
 
       <tr>
@@ -601,7 +601,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
 
-        <td>Since <code>C++14</code></td>
+        <td>No</td>
       </tr>
 
       <tr>
@@ -613,7 +613,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>T temp(u); temp -= t</code>.<br>
          Return convertible to <code>T</code>.</td>
 
-         <td>Since <code>C++14</code></td>
+         <td>No</td>
       </tr>
 
       <tr>
@@ -627,7 +627,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
 
-        <td>Since <code>C++14</code></td>
+        <td>No</td>
       </tr>
 
       <tr>
@@ -642,7 +642,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
 
-        <td>Since <code>C++14</code></td>
+        <td>No</td>
       </tr>
 
       <tr>
@@ -655,7 +655,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
 
-        <td>Since <code>C++14</code></td>
+        <td>No</td>
       </tr>
 
       <tr>
@@ -668,7 +668,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
 
-        <td>Since <code>C++14</code></td>
+        <td>No</td>
       </tr>
 
       <tr>
@@ -680,7 +680,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>T temp(u); temp /= t</code>.<br>
          Return convertible to <code>T</code>.</td>
 
-         <td>Since <code>C++14</code></td>
+         <td>No</td>
       </tr>
 
       <tr>
@@ -693,7 +693,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
 
-        <td>Since <code>C++14</code></td>
+        <td>No</td>
       </tr>
 
       <tr>
@@ -706,7 +706,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
 
-        <td>Since <code>C++14</code></td>
+        <td>No</td>
       </tr>
 
       <tr>
@@ -718,7 +718,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>T temp(u); temp %= t</code>.<br>
          Return convertible to <code>T</code>.</td>
 
-         <td>Since <code>C++14</code></td>
+         <td>No</td>
       </tr>
 
       <tr>
@@ -731,7 +731,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
 
-        <td>Since <code>C++14</code></td>
+        <td>No</td>
       </tr>
 
       <tr>
@@ -745,7 +745,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
 
-        <td>Since <code>C++14</code></td>
+        <td>No</td>
       </tr>
 
       <tr>
@@ -758,7 +758,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
 
-        <td>Since <code>C++14</code></td>
+        <td>No</td>
       </tr>
 
       <tr>
@@ -772,7 +772,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
 
-        <td>Since <code>C++14</code></td>
+        <td>No</td>
       </tr>
 
       <tr>
@@ -785,7 +785,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
 
-        <td>Since <code>C++14</code></td>
+        <td>No</td>
       </tr>
 
       <tr>
@@ -799,7 +799,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
 
-        <td>Since <code>C++14</code></td>
+        <td>No</td>
       </tr>
 
       <tr>
@@ -811,7 +811,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>T temp(t); ++t</code><br>
          Return convertible to <code>T</code>.</td>
 
-         <td>Since <code>C++14</code></td>
+         <td>No</td>
       </tr>
 
       <tr>
@@ -823,7 +823,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>T temp(t); --t;</code><br>
          Return convertible to <code>T</code>.</td>
 
-         <td>Since <code>C++14</code></td>
+         <td>No</td>
       </tr>
 
       <tr>
@@ -837,7 +837,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
 
-        <td>Since <code>C++14</code></td>
+        <td>No</td>
       </tr>
 
       <tr>
@@ -851,7 +851,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
 
-        <td>Since <code>C++14</code></td>
+        <td>No</td>
       </tr>
 
       <tr>
@@ -865,7 +865,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
 
-        <td>Since <code>C++14</code></td>
+        <td>No</td>
       </tr>
 
       <tr>
@@ -879,7 +879,7 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
          Return convertible to <code>T</code>. See the <a href=
         "#symmetry">Symmetry Note</a>.</td>
 
-        <td>Since <code>C++14</code></td>
+        <td>No</td>
       </tr>
 
       <tr>

--- a/operators.htm
+++ b/operators.htm
@@ -499,7 +499,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
          Return convertible to <code>bool</code>. See the <a href=
         "#ordering">Ordering Note</a>.</td>
 
-        <td>Since <code>C++11</code></td>
+        <td>Since <code>C++11</code><br>
+        <span style="font-size:small;">(except <a href="https://developercommunity.visualstudio.com/content/problem/414193/rejects-valid-constexpr-marked-friend-function-def.html">MSVC</a>)</span></td>
       </tr>
 
       <tr>
@@ -518,7 +519,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
          Returns convertible to <code>bool</code>. See the <a href=
         "#ordering">Ordering Note</a>.</td>
 
-        <td>Since <code>C++11</code></td>
+        <td>Since <code>C++11</code><br>
+        <span style="font-size:small;">(except <a href="https://developercommunity.visualstudio.com/content/problem/414193/rejects-valid-constexpr-marked-friend-function-def.html">MSVC</a>)</span></td>
       </tr>
 
       <tr>
@@ -531,7 +533,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>t == t1</code>.<br>
          Return convertible to <code>bool</code>.</td>
 
-        <td>Since <code>C++11</code></td>
+        <td>Since <code>C++11</code><br>
+        <span style="font-size:small;">(except <a href="https://developercommunity.visualstudio.com/content/problem/414193/rejects-valid-constexpr-marked-friend-function-def.html">MSVC</a>)</span></td>
       </tr>
 
       <tr>
@@ -546,7 +549,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
         <td><code>t == u</code>.<br>
          Return convertible to <code>bool</code>.</td>
 
-         <td>Since <code>C++11</code></td>
+         <td>Since <code>C++11</code><br>
+        <span style="font-size:small;">(except <a href="https://developercommunity.visualstudio.com/content/problem/414193/rejects-valid-constexpr-marked-friend-function-def.html">MSVC</a>)</span></td>
       </tr>
 
       <tr>
@@ -892,7 +896,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
          Return convertible to <code>bool</code>. See the <a href=
         "#ordering">Ordering Note</a>.</td>
 
-        <td>Since <code>C++11</code></td>
+        <td>Since <code>C++11</code><br>
+        <span style="font-size:small;">(except <a href="https://developercommunity.visualstudio.com/content/problem/414193/rejects-valid-constexpr-marked-friend-function-def.html">MSVC</a>)</span></td>
       </tr>
 
       <tr>
@@ -905,7 +910,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
          Returns convertible to <code>bool</code>. See the <a href=
         "#ordering">Ordering Note</a>.</td>
 
-        <td>Since <code>C++11</code></td>
+        <td>Since <code>C++11</code><br>
+        <span style="font-size:small;">(except <a href="https://developercommunity.visualstudio.com/content/problem/414193/rejects-valid-constexpr-marked-friend-function-def.html">MSVC</a>)</span></td>
       </tr>
 
       <tr>
@@ -921,7 +927,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
          Returns convertible to <code>bool</code>. See the <a href=
         "#ordering">Ordering Note</a>.</td>
 
-        <td>Since <code>C++11</code></td>
+        <td>Since <code>C++11</code><br>
+        <span style="font-size:small;">(except <a href="https://developercommunity.visualstudio.com/content/problem/414193/rejects-valid-constexpr-marked-friend-function-def.html">MSVC</a>)</span></td>
       </tr>
 
       <tr>
@@ -941,7 +948,8 @@ const point&lt;float&gt; pi_over_4_normalized = pi_over_4 / length(pi_over_4);
          Returns convertible to <code>bool</code>. See the <a href=
         "#ordering">Ordering Note</a>.</td>
 
-        <td>Since <code>C++11</code></td>
+        <td>Since <code>C++11</code><br>
+        <span style="font-size:small;">(except <a href="https://developercommunity.visualstudio.com/content/problem/414193/rejects-valid-constexpr-marked-friend-function-def.html">MSVC</a>)</span></td>
       </tr>
     </table>
 

--- a/test/operators_test.cpp
+++ b/test/operators_test.cpp
@@ -72,28 +72,28 @@ namespace
         BOOST_CONSTEXPR convertible_to_bool operator==(const Wrapped1& x) const
           { return _value == x._value; }
         
-        BOOST_CXX14_CONSTEXPR Wrapped1& operator+=(const Wrapped1& x)
+        Wrapped1& operator+=(const Wrapped1& x)
           { _value += x._value; return *this; }
-        BOOST_CXX14_CONSTEXPR Wrapped1& operator-=(const Wrapped1& x)
+        Wrapped1& operator-=(const Wrapped1& x)
           { _value -= x._value; return *this; }
-        BOOST_CXX14_CONSTEXPR Wrapped1& operator*=(const Wrapped1& x)
+        Wrapped1& operator*=(const Wrapped1& x)
           { _value *= x._value; return *this; }
-        BOOST_CXX14_CONSTEXPR Wrapped1& operator/=(const Wrapped1& x)
+        Wrapped1& operator/=(const Wrapped1& x)
           { _value /= x._value; return *this; }
-        BOOST_CXX14_CONSTEXPR Wrapped1& operator%=(const Wrapped1& x)
+        Wrapped1& operator%=(const Wrapped1& x)
           { _value %= x._value; return *this; }
-        BOOST_CXX14_CONSTEXPR Wrapped1& operator|=(const Wrapped1& x)
+        Wrapped1& operator|=(const Wrapped1& x)
           { _value |= x._value; return *this; }
-        BOOST_CXX14_CONSTEXPR Wrapped1& operator&=(const Wrapped1& x)
+        Wrapped1& operator&=(const Wrapped1& x)
           { _value &= x._value; return *this; }
-        BOOST_CXX14_CONSTEXPR Wrapped1& operator^=(const Wrapped1& x)
+        Wrapped1& operator^=(const Wrapped1& x)
           { _value ^= x._value; return *this; }
-        BOOST_CXX14_CONSTEXPR Wrapped1& operator<<=(const Wrapped1& x)
+        Wrapped1& operator<<=(const Wrapped1& x)
           { _value <<= x._value; return *this; }
-        BOOST_CXX14_CONSTEXPR Wrapped1& operator>>=(const Wrapped1& x)
+        Wrapped1& operator>>=(const Wrapped1& x)
           { _value >>= x._value; return *this; }
-        BOOST_CXX14_CONSTEXPR Wrapped1& operator++() { ++_value; return *this; }
-        BOOST_CXX14_CONSTEXPR Wrapped1& operator--() { --_value; return *this; }
+        Wrapped1& operator++() { ++_value; return *this; }
+        Wrapped1& operator--() { --_value; return *this; }
         
     private:
         T _value;
@@ -954,41 +954,6 @@ main()
     static_assert(                      MyInt{ 1 } <= MyInt{ 1 },   "" );
     static_assert( ! static_cast<bool>( MyInt{ 1 } >  MyInt{ 1 } ), "" );
     static_assert(                      MyInt{ 1 } >= MyInt{ 1 },   "" );
-#endif
-
-// Where C++14 constexpr is available, compile-time test some of the operators that are able to use it to propagate constexpr
-#ifndef BOOST_NO_CXX14_CONSTEXPR
-    static_assert( ( MyInt{ 1 } +  MyInt{ 2 } ) == MyInt{ 3 }, "" );
-    static_assert( ( MyInt{ 2 } +  MyInt{ 1 } ) == MyInt{ 3 }, "" );
-    static_assert( ( MyInt{ 2 } +  MyInt{ 1 } ) == MyInt{ 3 }, "" );
-    static_assert( ( MyInt{ 2 } +  MyInt{ 2 } ) == MyInt{ 4 }, "" );
-    static_assert( ( MyInt{ 3 } +  MyInt{ 2 } ) == MyInt{ 5 }, "" );
-
-    static_assert( ( MyInt{ 5 } -  MyInt{ 1 } ) == MyInt{ 4 }, "" );
-
-    static_assert( ( MyInt{ 3 } *  MyInt{ 3 } ) == MyInt{ 9 }, "" );
-    static_assert( ( MyInt{ 4 } *  MyInt{ 2 } ) == MyInt{ 8 }, "" );
-
-    static_assert( ( MyInt{ 8 } /  MyInt{ 2 } ) == MyInt{ 4 }, "" );
-
-    static_assert( ( MyInt{ 4 } %  MyInt{ 3 } ) == MyInt{ 1 }, "" );
-
-
-    static_assert( ( MyInt{ 7 } &  MyInt{ 2 } ) == MyInt{ 2 }, "" );
-
-    static_assert( ( MyInt{ 1 } |  MyInt{ 2 } ) == MyInt{ 3 }, "" );
-    static_assert( ( MyInt{ 1 } |  MyInt{ 4 } ) == MyInt{ 5 }, "" );
-    static_assert( ( MyInt{ 2 } |  MyInt{ 1 } ) == MyInt{ 3 }, "" );
-    static_assert( ( MyInt{ 2 } |  MyInt{ 4 } ) == MyInt{ 6 }, "" );
-    static_assert( ( MyInt{ 3 } |  MyInt{ 4 } ) == MyInt{ 7 }, "" );
-    static_assert( ( MyInt{ 5 } |  MyInt{ 2 } ) == MyInt{ 7 }, "" );
-    static_assert( ( MyInt{ 6 } |  MyInt{ 1 } ) == MyInt{ 7 }, "" );
-
-    static_assert( ( MyInt{ 3 } ^  MyInt{ 1 } ) == MyInt{ 2 }, "" );
-
-
-    static_assert( ( MyInt{ 1 } << MyInt{ 2 } ) == MyInt{ 4 }, "" );
-    static_assert( ( MyInt{ 2 } >> MyInt{ 1 } ) == MyInt{ 1 }, "" );
 #endif
 
     return boost::report_errors();

--- a/test/operators_test.cpp
+++ b/test/operators_test.cpp
@@ -50,9 +50,9 @@ namespace
         void operator!() const;
 
     public:
-        BOOST_CONSTEXPR convertible_to_bool( const bool value ) : _value( value ) {}
+        BOOST_OPS_CONSTEXPR convertible_to_bool( const bool value ) : _value( value ) {}
 
-        BOOST_CONSTEXPR operator unspecified_bool_type() const
+        BOOST_OPS_CONSTEXPR operator unspecified_bool_type() const
           { return _value ? &convertible_to_bool::_value : 0; }
     };
 
@@ -64,12 +64,12 @@ namespace
         , boost::shiftable<Wrapped1<T> >
     {
     public:
-        BOOST_CONSTEXPR explicit Wrapped1( T v = T() ) : _value(v) {}
-        BOOST_CONSTEXPR T value() const { return _value; }
+        BOOST_OPS_CONSTEXPR explicit Wrapped1( T v = T() ) : _value(v) {}
+        BOOST_OPS_CONSTEXPR T value() const { return _value; }
 
-        BOOST_CONSTEXPR convertible_to_bool operator<(const Wrapped1& x) const
+        BOOST_OPS_CONSTEXPR convertible_to_bool operator<(const Wrapped1& x) const
           { return _value < x._value; }
-        BOOST_CONSTEXPR convertible_to_bool operator==(const Wrapped1& x) const
+        BOOST_OPS_CONSTEXPR convertible_to_bool operator==(const Wrapped1& x) const
           { return _value == x._value; }
         
         Wrapped1& operator+=(const Wrapped1& x)
@@ -934,6 +934,7 @@ main()
 
 // Where C++11 constexpr is available, compile-time test some of the operators that are able to use it to propagate constexpr
 #ifndef BOOST_NO_CXX11_CONSTEXPR
+#ifndef BOOST_MSVC
     static_assert( ! static_cast<bool>( MyInt{ 1 } == MyInt{ 2 } ), "" );
     static_assert(                      MyInt{ 1 } != MyInt{ 2 },   "" );
     static_assert(                      MyInt{ 1 } <  MyInt{ 2 },   "" );
@@ -954,6 +955,7 @@ main()
     static_assert(                      MyInt{ 1 } <= MyInt{ 1 },   "" );
     static_assert( ! static_cast<bool>( MyInt{ 1 } >  MyInt{ 1 } ), "" );
     static_assert(                      MyInt{ 1 } >= MyInt{ 1 },   "" );
+#endif
 #endif
 
     return boost::report_errors();

--- a/test/operators_test.cpp
+++ b/test/operators_test.cpp
@@ -934,7 +934,7 @@ main()
 
 // Where C++11 constexpr is available, compile-time test some of the operators that are able to use it to propagate constexpr
 #ifndef BOOST_NO_CXX11_CONSTEXPR
-#ifndef BOOST_MSVC
+#if !defined(BOOST_MSVC) || (_MSC_VER >= 1922)
     static_assert( ! static_cast<bool>( MyInt{ 1 } == MyInt{ 2 } ), "" );
     static_assert(                      MyInt{ 1 } != MyInt{ 2 },   "" );
     static_assert(                      MyInt{ 1 } <  MyInt{ 2 },   "" );

--- a/test/operators_test.cpp
+++ b/test/operators_test.cpp
@@ -50,9 +50,9 @@ namespace
         void operator!() const;
 
     public:
-        convertible_to_bool( const bool value ) : _value( value ) {}
+        BOOST_CONSTEXPR convertible_to_bool( const bool value ) : _value( value ) {}
 
-        operator unspecified_bool_type() const
+        BOOST_CONSTEXPR operator unspecified_bool_type() const
           { return _value ? &convertible_to_bool::_value : 0; }
     };
 
@@ -64,36 +64,36 @@ namespace
         , boost::shiftable<Wrapped1<T> >
     {
     public:
-        explicit Wrapped1( T v = T() ) : _value(v) {}
-        T value() const { return _value; }
+        BOOST_CONSTEXPR explicit Wrapped1( T v = T() ) : _value(v) {}
+        BOOST_CONSTEXPR T value() const { return _value; }
 
-        convertible_to_bool operator<(const Wrapped1& x) const
+        BOOST_CONSTEXPR convertible_to_bool operator<(const Wrapped1& x) const
           { return _value < x._value; }
-        convertible_to_bool operator==(const Wrapped1& x) const
+        BOOST_CONSTEXPR convertible_to_bool operator==(const Wrapped1& x) const
           { return _value == x._value; }
         
-        Wrapped1& operator+=(const Wrapped1& x)
+        BOOST_CXX14_CONSTEXPR Wrapped1& operator+=(const Wrapped1& x)
           { _value += x._value; return *this; }
-        Wrapped1& operator-=(const Wrapped1& x)
+        BOOST_CXX14_CONSTEXPR Wrapped1& operator-=(const Wrapped1& x)
           { _value -= x._value; return *this; }
-        Wrapped1& operator*=(const Wrapped1& x)
+        BOOST_CXX14_CONSTEXPR Wrapped1& operator*=(const Wrapped1& x)
           { _value *= x._value; return *this; }
-        Wrapped1& operator/=(const Wrapped1& x)
+        BOOST_CXX14_CONSTEXPR Wrapped1& operator/=(const Wrapped1& x)
           { _value /= x._value; return *this; }
-        Wrapped1& operator%=(const Wrapped1& x)
+        BOOST_CXX14_CONSTEXPR Wrapped1& operator%=(const Wrapped1& x)
           { _value %= x._value; return *this; }
-        Wrapped1& operator|=(const Wrapped1& x)
+        BOOST_CXX14_CONSTEXPR Wrapped1& operator|=(const Wrapped1& x)
           { _value |= x._value; return *this; }
-        Wrapped1& operator&=(const Wrapped1& x)
+        BOOST_CXX14_CONSTEXPR Wrapped1& operator&=(const Wrapped1& x)
           { _value &= x._value; return *this; }
-        Wrapped1& operator^=(const Wrapped1& x)
+        BOOST_CXX14_CONSTEXPR Wrapped1& operator^=(const Wrapped1& x)
           { _value ^= x._value; return *this; }
-        Wrapped1& operator<<=(const Wrapped1& x)
+        BOOST_CXX14_CONSTEXPR Wrapped1& operator<<=(const Wrapped1& x)
           { _value <<= x._value; return *this; }
-        Wrapped1& operator>>=(const Wrapped1& x)
+        BOOST_CXX14_CONSTEXPR Wrapped1& operator>>=(const Wrapped1& x)
           { _value >>= x._value; return *this; }
-        Wrapped1& operator++()               { ++_value; return *this; }
-        Wrapped1& operator--()               { --_value; return *this; }
+        BOOST_CXX14_CONSTEXPR Wrapped1& operator++() { ++_value; return *this; }
+        BOOST_CXX14_CONSTEXPR Wrapped1& operator--() { --_value; return *this; }
         
     private:
         T _value;
@@ -931,6 +931,65 @@ main()
     PRIVATE_EXPR_TEST( (tmp2=li1), static_cast<bool>((tmp2+=li1) == li2) );
 
     cout << "Performed tests on MyLongInt objects.\n";
+
+// Where C++11 constexpr is available, compile-time test some of the operators that are able to use it to propagate constexpr
+#ifndef BOOST_NO_CXX11_CONSTEXPR
+    static_assert( ! static_cast<bool>( MyInt{ 1 } == MyInt{ 2 } ), "" );
+    static_assert(                      MyInt{ 1 } != MyInt{ 2 },   "" );
+    static_assert(                      MyInt{ 1 } <  MyInt{ 2 },   "" );
+    static_assert(                      MyInt{ 1 } <= MyInt{ 2 },   "" );
+    static_assert( ! static_cast<bool>( MyInt{ 1 } >  MyInt{ 2 } ), "" );
+    static_assert( ! static_cast<bool>( MyInt{ 1 } >= MyInt{ 2 } ), "" );
+
+    static_assert( ! static_cast<bool>( MyInt{ 2 } == MyInt{ 1 } ), "" );
+    static_assert(                      MyInt{ 2 } != MyInt{ 1 },   "" );
+    static_assert( ! static_cast<bool>( MyInt{ 2 } <  MyInt{ 1 } ), "" );
+    static_assert( ! static_cast<bool>( MyInt{ 2 } <= MyInt{ 1 } ), "" );
+    static_assert(                      MyInt{ 2 } >  MyInt{ 1 },   "" );
+    static_assert(                      MyInt{ 2 } >= MyInt{ 1 },   "" );
+
+    static_assert(                      MyInt{ 1 } == MyInt{ 1 },   "" );
+    static_assert( ! static_cast<bool>( MyInt{ 1 } != MyInt{ 1 } ), "" );
+    static_assert( ! static_cast<bool>( MyInt{ 1 } <  MyInt{ 1 } ), "" );
+    static_assert(                      MyInt{ 1 } <= MyInt{ 1 },   "" );
+    static_assert( ! static_cast<bool>( MyInt{ 1 } >  MyInt{ 1 } ), "" );
+    static_assert(                      MyInt{ 1 } >= MyInt{ 1 },   "" );
+#endif
+
+// Where C++14 constexpr is available, compile-time test some of the operators that are able to use it to propagate constexpr
+#ifndef BOOST_NO_CXX14_CONSTEXPR
+    static_assert( ( MyInt{ 1 } +  MyInt{ 2 } ) == MyInt{ 3 }, "" );
+    static_assert( ( MyInt{ 2 } +  MyInt{ 1 } ) == MyInt{ 3 }, "" );
+    static_assert( ( MyInt{ 2 } +  MyInt{ 1 } ) == MyInt{ 3 }, "" );
+    static_assert( ( MyInt{ 2 } +  MyInt{ 2 } ) == MyInt{ 4 }, "" );
+    static_assert( ( MyInt{ 3 } +  MyInt{ 2 } ) == MyInt{ 5 }, "" );
+
+    static_assert( ( MyInt{ 5 } -  MyInt{ 1 } ) == MyInt{ 4 }, "" );
+
+    static_assert( ( MyInt{ 3 } *  MyInt{ 3 } ) == MyInt{ 9 }, "" );
+    static_assert( ( MyInt{ 4 } *  MyInt{ 2 } ) == MyInt{ 8 }, "" );
+
+    static_assert( ( MyInt{ 8 } /  MyInt{ 2 } ) == MyInt{ 4 }, "" );
+
+    static_assert( ( MyInt{ 4 } %  MyInt{ 3 } ) == MyInt{ 1 }, "" );
+
+
+    static_assert( ( MyInt{ 7 } &  MyInt{ 2 } ) == MyInt{ 2 }, "" );
+
+    static_assert( ( MyInt{ 1 } |  MyInt{ 2 } ) == MyInt{ 3 }, "" );
+    static_assert( ( MyInt{ 1 } |  MyInt{ 4 } ) == MyInt{ 5 }, "" );
+    static_assert( ( MyInt{ 2 } |  MyInt{ 1 } ) == MyInt{ 3 }, "" );
+    static_assert( ( MyInt{ 2 } |  MyInt{ 4 } ) == MyInt{ 6 }, "" );
+    static_assert( ( MyInt{ 3 } |  MyInt{ 4 } ) == MyInt{ 7 }, "" );
+    static_assert( ( MyInt{ 5 } |  MyInt{ 2 } ) == MyInt{ 7 }, "" );
+    static_assert( ( MyInt{ 6 } |  MyInt{ 1 } ) == MyInt{ 7 }, "" );
+
+    static_assert( ( MyInt{ 3 } ^  MyInt{ 1 } ) == MyInt{ 2 }, "" );
+
+
+    static_assert( ( MyInt{ 1 } << MyInt{ 2 } ) == MyInt{ 4 }, "" );
+    static_assert( ( MyInt{ 2 } >> MyInt{ 1 } ) == MyInt{ 1 }, "" );
+#endif
 
     return boost::report_errors();
 }


### PR DESCRIPTION
Following on from #54, this adds `constexpr` support to Boost.Operators.

