### PR TITLE
Update to Operators constexpr support 

### DIFF
--- a/include/boost/operators.hpp
+++ b/include/boost/operators.hpp
@@ -110,12 +110,8 @@
 #endif                               // operator-> not begin a UDT
 
 // Define BOOST_OPERATORS_CONSTEXPR to be like BOOST_CONSTEXPR but empty under MSVC < v19.22
-#ifdef BOOST_MSVC
-#if BOOST_MSVC_FULL_VER >= 192200000
-#define BOOST_OPERATORS_CONSTEXPR constexpr
-#else
+#if BOOST_WORKAROUND(BOOST_MSVC, < 1922)
 #define BOOST_OPERATORS_CONSTEXPR
-#endif
 #else
 #define BOOST_OPERATORS_CONSTEXPR BOOST_CONSTEXPR
 #endif

--- a/include/boost/operators.hpp
+++ b/include/boost/operators.hpp
@@ -109,15 +109,15 @@
 #   pragma warning( disable : 4284 ) // complaint about return type of
 #endif                               // operator-> not begin a UDT
 
-// Define BOOST_OPS_CONSTEXPR to be like BOOST_CONSTEXPR but empty under MSVC < v19.22
+// Define BOOST_OPERATORS_CONSTEXPR to be like BOOST_CONSTEXPR but empty under MSVC < v19.22
 #ifdef BOOST_MSVC
 #if BOOST_MSVC_FULL_VER >= 192200000
-#define BOOST_OPS_CONSTEXPR constexpr
+#define BOOST_OPERATORS_CONSTEXPR constexpr
 #else
-#define BOOST_OPS_CONSTEXPR
+#define BOOST_OPERATORS_CONSTEXPR
 #endif
 #else
-#define BOOST_OPS_CONSTEXPR BOOST_CONSTEXPR
+#define BOOST_OPERATORS_CONSTEXPR BOOST_CONSTEXPR
 #endif
 
 // In this section we supply the xxxx1 and xxxx2 forms of the operator
@@ -143,34 +143,34 @@ template <typename T> class empty_base {};
 template <class T, class U, class B = operators_detail::empty_base<T> >
 struct less_than_comparable2 : B
 {
-     friend BOOST_OPS_CONSTEXPR bool operator<=(const T& x, const U& y) { return !static_cast<bool>(x > y); }
-     friend BOOST_OPS_CONSTEXPR bool operator>=(const T& x, const U& y) { return !static_cast<bool>(x < y); }
-     friend BOOST_OPS_CONSTEXPR bool operator>(const U& x, const T& y)  { return y < x; }
-     friend BOOST_OPS_CONSTEXPR bool operator<(const U& x, const T& y)  { return y > x; }
-     friend BOOST_OPS_CONSTEXPR bool operator<=(const U& x, const T& y) { return !static_cast<bool>(y < x); }
-     friend BOOST_OPS_CONSTEXPR bool operator>=(const U& x, const T& y) { return !static_cast<bool>(y > x); }
+     friend BOOST_OPERATORS_CONSTEXPR bool operator<=(const T& x, const U& y) { return !static_cast<bool>(x > y); }
+     friend BOOST_OPERATORS_CONSTEXPR bool operator>=(const T& x, const U& y) { return !static_cast<bool>(x < y); }
+     friend BOOST_OPERATORS_CONSTEXPR bool operator>(const U& x, const T& y)  { return y < x; }
+     friend BOOST_OPERATORS_CONSTEXPR bool operator<(const U& x, const T& y)  { return y > x; }
+     friend BOOST_OPERATORS_CONSTEXPR bool operator<=(const U& x, const T& y) { return !static_cast<bool>(y < x); }
+     friend BOOST_OPERATORS_CONSTEXPR bool operator>=(const U& x, const T& y) { return !static_cast<bool>(y > x); }
 };
 
 template <class T, class B = operators_detail::empty_base<T> >
 struct less_than_comparable1 : B
 {
-     friend BOOST_OPS_CONSTEXPR bool operator>(const T& x, const T& y)  { return y < x; }
-     friend BOOST_OPS_CONSTEXPR bool operator<=(const T& x, const T& y) { return !static_cast<bool>(y < x); }
-     friend BOOST_OPS_CONSTEXPR bool operator>=(const T& x, const T& y) { return !static_cast<bool>(x < y); }
+     friend BOOST_OPERATORS_CONSTEXPR bool operator>(const T& x, const T& y)  { return y < x; }
+     friend BOOST_OPERATORS_CONSTEXPR bool operator<=(const T& x, const T& y) { return !static_cast<bool>(y < x); }
+     friend BOOST_OPERATORS_CONSTEXPR bool operator>=(const T& x, const T& y) { return !static_cast<bool>(x < y); }
 };
 
 template <class T, class U, class B = operators_detail::empty_base<T> >
 struct equality_comparable2 : B
 {
-     friend BOOST_OPS_CONSTEXPR bool operator==(const U& y, const T& x) { return x == y; }
-     friend BOOST_OPS_CONSTEXPR bool operator!=(const U& y, const T& x) { return !static_cast<bool>(x == y); }
-     friend BOOST_OPS_CONSTEXPR bool operator!=(const T& y, const U& x) { return !static_cast<bool>(y == x); }
+     friend BOOST_OPERATORS_CONSTEXPR bool operator==(const U& y, const T& x) { return x == y; }
+     friend BOOST_OPERATORS_CONSTEXPR bool operator!=(const U& y, const T& x) { return !static_cast<bool>(x == y); }
+     friend BOOST_OPERATORS_CONSTEXPR bool operator!=(const T& y, const U& x) { return !static_cast<bool>(y == x); }
 };
 
 template <class T, class B = operators_detail::empty_base<T> >
 struct equality_comparable1 : B
 {
-     friend BOOST_OPS_CONSTEXPR bool operator!=(const T& x, const T& y) { return !static_cast<bool>(x == y); }
+     friend BOOST_OPERATORS_CONSTEXPR bool operator!=(const T& x, const T& y) { return !static_cast<bool>(x == y); }
 };
 
 // A macro which produces "name_2left" from "name".
@@ -373,7 +373,7 @@ BOOST_BINARY_OPERATOR( right_shiftable, >> )
 template <class T, class U, class B = operators_detail::empty_base<T> >
 struct equivalent2 : B
 {
-  friend BOOST_OPS_CONSTEXPR bool operator==(const T& x, const U& y)
+  friend BOOST_OPERATORS_CONSTEXPR bool operator==(const T& x, const U& y)
   {
     return !static_cast<bool>(x < y) && !static_cast<bool>(x > y);
   }
@@ -382,7 +382,7 @@ struct equivalent2 : B
 template <class T, class B = operators_detail::empty_base<T> >
 struct equivalent1 : B
 {
-  friend BOOST_OPS_CONSTEXPR bool operator==(const T&x, const T&y)
+  friend BOOST_OPERATORS_CONSTEXPR bool operator==(const T&x, const T&y)
   {
     return !static_cast<bool>(x < y) && !static_cast<bool>(y < x);
   }
@@ -391,28 +391,28 @@ struct equivalent1 : B
 template <class T, class U, class B = operators_detail::empty_base<T> >
 struct partially_ordered2 : B
 {
-  friend BOOST_OPS_CONSTEXPR bool operator<=(const T& x, const U& y)
+  friend BOOST_OPERATORS_CONSTEXPR bool operator<=(const T& x, const U& y)
     { return static_cast<bool>(x < y) || static_cast<bool>(x == y); }
-  friend BOOST_OPS_CONSTEXPR bool operator>=(const T& x, const U& y)
+  friend BOOST_OPERATORS_CONSTEXPR bool operator>=(const T& x, const U& y)
     { return static_cast<bool>(x > y) || static_cast<bool>(x == y); }
-  friend BOOST_OPS_CONSTEXPR bool operator>(const U& x, const T& y)
+  friend BOOST_OPERATORS_CONSTEXPR bool operator>(const U& x, const T& y)
     { return y < x; }
-  friend BOOST_OPS_CONSTEXPR bool operator<(const U& x, const T& y)
+  friend BOOST_OPERATORS_CONSTEXPR bool operator<(const U& x, const T& y)
     { return y > x; }
-  friend BOOST_OPS_CONSTEXPR bool operator<=(const U& x, const T& y)
+  friend BOOST_OPERATORS_CONSTEXPR bool operator<=(const U& x, const T& y)
     { return static_cast<bool>(y > x) || static_cast<bool>(y == x); }
-  friend BOOST_OPS_CONSTEXPR bool operator>=(const U& x, const T& y)
+  friend BOOST_OPERATORS_CONSTEXPR bool operator>=(const U& x, const T& y)
     { return static_cast<bool>(y < x) || static_cast<bool>(y == x); }
 };
 
 template <class T, class B = operators_detail::empty_base<T> >
 struct partially_ordered1 : B
 {
-  friend BOOST_OPS_CONSTEXPR bool operator>(const T& x, const T& y)
+  friend BOOST_OPERATORS_CONSTEXPR bool operator>(const T& x, const T& y)
     { return y < x; }
-  friend BOOST_OPS_CONSTEXPR bool operator<=(const T& x, const T& y)
+  friend BOOST_OPERATORS_CONSTEXPR bool operator<=(const T& x, const T& y)
     { return static_cast<bool>(x < y) || static_cast<bool>(x == y); }
-  friend BOOST_OPS_CONSTEXPR bool operator>=(const T& x, const T& y)
+  friend BOOST_OPERATORS_CONSTEXPR bool operator>=(const T& x, const T& y)
     { return static_cast<bool>(y < x) || static_cast<bool>(x == y); }
 };
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -21,6 +21,7 @@ run compressed_pair_final_test.cpp ;
 run iterators_test.cpp ;
 
 run operators_test.cpp ;
+compile operators_constexpr_test.cpp ;
 
 compile result_of_test.cpp ;
 

--- a/test/operators_constexpr_test.cpp
+++ b/test/operators_constexpr_test.cpp
@@ -1,0 +1,59 @@
+/*
+Copyright 2020 Glen Joseph Fernandes
+(glenjofe@gmail.com)
+
+Distributed under the Boost Software License, Version 1.0.
+(http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#include <boost/config.hpp>
+#if !defined(BOOST_NO_CXX11_CONSTEXPR) && \
+    (!defined(BOOST_MSVC) || (BOOST_MSVC >= 1922))
+#include <boost/operators.hpp>
+#include <boost/static_assert.hpp>
+
+namespace {
+
+class Value
+    : boost::operators<Value> {
+public:
+    BOOST_OPS_CONSTEXPR explicit Value(int v)
+        : v_(v) { }
+
+    BOOST_OPS_CONSTEXPR bool
+    operator<(const Value& x) const {
+        return v_ < x.v_;
+    }
+
+    BOOST_OPS_CONSTEXPR bool
+    operator==(const Value& x) const {
+        return v_ == x.v_;
+    }
+
+private:
+    int v_;
+};
+
+} // namespace
+
+BOOST_STATIC_ASSERT(!static_cast<bool>(Value(1) == Value(2)));
+BOOST_STATIC_ASSERT(Value(1) != Value(2));
+BOOST_STATIC_ASSERT(Value(1) < Value(2));
+BOOST_STATIC_ASSERT(Value(1) <= Value(2));
+BOOST_STATIC_ASSERT(!static_cast<bool>(Value(1) > Value(2)));
+BOOST_STATIC_ASSERT(!static_cast<bool>(Value(1) >= Value(2)));
+
+BOOST_STATIC_ASSERT(!static_cast<bool>(Value(2) == Value(1)));
+BOOST_STATIC_ASSERT(Value(2) != Value(1));
+BOOST_STATIC_ASSERT(!static_cast<bool>(Value(2) < Value(1)));
+BOOST_STATIC_ASSERT(!static_cast<bool>(Value(2) <= Value(1)));
+BOOST_STATIC_ASSERT(Value(2) >  Value(1));
+BOOST_STATIC_ASSERT(Value(2) >= Value(1));
+
+BOOST_STATIC_ASSERT(Value(1) == Value(1));
+BOOST_STATIC_ASSERT(!static_cast<bool>(Value(1) != Value(1)));
+BOOST_STATIC_ASSERT(!static_cast<bool>(Value(1) < Value(1)));
+BOOST_STATIC_ASSERT(Value(1) <= Value(1));
+BOOST_STATIC_ASSERT(!static_cast<bool>(Value(1) > Value(1)));
+BOOST_STATIC_ASSERT(Value(1) >= Value(1));
+#endif

--- a/test/operators_constexpr_test.cpp
+++ b/test/operators_constexpr_test.cpp
@@ -17,15 +17,15 @@ namespace {
 class Value
     : boost::operators<Value> {
 public:
-    BOOST_OPS_CONSTEXPR explicit Value(int v)
+    BOOST_OPERATORS_CONSTEXPR explicit Value(int v)
         : v_(v) { }
 
-    BOOST_OPS_CONSTEXPR bool
+    BOOST_OPERATORS_CONSTEXPR bool
     operator<(const Value& x) const {
         return v_ < x.v_;
     }
 
-    BOOST_OPS_CONSTEXPR bool
+    BOOST_OPERATORS_CONSTEXPR bool
     operator==(const Value& x) const {
         return v_ == x.v_;
     }

--- a/test/operators_test.cpp
+++ b/test/operators_test.cpp
@@ -50,9 +50,9 @@ namespace
         void operator!() const;
 
     public:
-        BOOST_OPS_CONSTEXPR convertible_to_bool( const bool value ) : _value( value ) {}
+         convertible_to_bool( const bool value ) : _value( value ) {}
 
-        BOOST_OPS_CONSTEXPR operator unspecified_bool_type() const
+         operator unspecified_bool_type() const
           { return _value ? &convertible_to_bool::_value : 0; }
     };
 
@@ -64,12 +64,12 @@ namespace
         , boost::shiftable<Wrapped1<T> >
     {
     public:
-        BOOST_OPS_CONSTEXPR explicit Wrapped1( T v = T() ) : _value(v) {}
-        BOOST_OPS_CONSTEXPR T value() const { return _value; }
+         explicit Wrapped1( T v = T() ) : _value(v) {}
+         T value() const { return _value; }
 
-        BOOST_OPS_CONSTEXPR convertible_to_bool operator<(const Wrapped1& x) const
+         convertible_to_bool operator<(const Wrapped1& x) const
           { return _value < x._value; }
-        BOOST_OPS_CONSTEXPR convertible_to_bool operator==(const Wrapped1& x) const
+         convertible_to_bool operator==(const Wrapped1& x) const
           { return _value == x._value; }
         
         Wrapped1& operator+=(const Wrapped1& x)
@@ -931,32 +931,6 @@ main()
     PRIVATE_EXPR_TEST( (tmp2=li1), static_cast<bool>((tmp2+=li1) == li2) );
 
     cout << "Performed tests on MyLongInt objects.\n";
-
-// Where C++11 constexpr is available, compile-time test some of the operators that are able to use it to propagate constexpr
-#ifndef BOOST_NO_CXX11_CONSTEXPR
-#if !defined(BOOST_MSVC) || (_MSC_VER >= 1922)
-    static_assert( ! static_cast<bool>( MyInt{ 1 } == MyInt{ 2 } ), "" );
-    static_assert(                      MyInt{ 1 } != MyInt{ 2 },   "" );
-    static_assert(                      MyInt{ 1 } <  MyInt{ 2 },   "" );
-    static_assert(                      MyInt{ 1 } <= MyInt{ 2 },   "" );
-    static_assert( ! static_cast<bool>( MyInt{ 1 } >  MyInt{ 2 } ), "" );
-    static_assert( ! static_cast<bool>( MyInt{ 1 } >= MyInt{ 2 } ), "" );
-
-    static_assert( ! static_cast<bool>( MyInt{ 2 } == MyInt{ 1 } ), "" );
-    static_assert(                      MyInt{ 2 } != MyInt{ 1 },   "" );
-    static_assert( ! static_cast<bool>( MyInt{ 2 } <  MyInt{ 1 } ), "" );
-    static_assert( ! static_cast<bool>( MyInt{ 2 } <= MyInt{ 1 } ), "" );
-    static_assert(                      MyInt{ 2 } >  MyInt{ 1 },   "" );
-    static_assert(                      MyInt{ 2 } >= MyInt{ 1 },   "" );
-
-    static_assert(                      MyInt{ 1 } == MyInt{ 1 },   "" );
-    static_assert( ! static_cast<bool>( MyInt{ 1 } != MyInt{ 1 } ), "" );
-    static_assert( ! static_cast<bool>( MyInt{ 1 } <  MyInt{ 1 } ), "" );
-    static_assert(                      MyInt{ 1 } <= MyInt{ 1 },   "" );
-    static_assert( ! static_cast<bool>( MyInt{ 1 } >  MyInt{ 1 } ), "" );
-    static_assert(                      MyInt{ 1 } >= MyInt{ 1 },   "" );
-#endif
-#endif
 
     return boost::report_errors();
 }


### PR DESCRIPTION
The following changes:
- Use a separate compile-only test for `constexpr` support so that any defects relating to `constexpr` do not impact the normal operators tests. Use `BOOST_STATIC_ASSERT` in the tests to avoid any issues with implementation with a defective `static_assert`.
- Rename `BOOST_OPS_CONSTEXPR` to `BOOST_OPERATORS_CONSTEXPR` to not introduce a new macro convention into the mix.
- Simplify the definition of `BOOST_OPERATORS_CONSTEXPR` with `BOOST_WORKAROUND`.