### PR TITLE
Cease dependence on ContainerHash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,6 @@ target_include_directories(boost_utility INTERFACE include)
 target_link_libraries(boost_utility
     INTERFACE
         Boost::config
-        Boost::container_hash
         Boost::core
         Boost::io
         Boost::preprocessor

--- a/include/boost/utility/string_view.hpp
+++ b/include/boost/utility/string_view.hpp
@@ -23,7 +23,6 @@
 #include <boost/io/ostream_put.hpp>
 #include <boost/utility/string_view_fwd.hpp>
 #include <boost/throw_exception.hpp>
-#include <boost/container_hash/hash_fwd.hpp>
 
 #include <cstddef>
 #include <stdexcept>
@@ -651,6 +650,9 @@ namespace boost {
         return std::stold ( std::wstring(str), idx );
         }
 #endif
+
+    // Forward declaration of Boost.ContainerHash function
+    template <class It> std::size_t hash_range(It, It);
 
     template <class charT, class traits>
     std::size_t hash_value(basic_string_view<charT, traits> s) {


### PR DESCRIPTION
by local `hash_range` forward declaration