### PR TITLE
Update metadata

### DIFF
--- a/meta/libraries.json
+++ b/meta/libraries.json
@@ -107,7 +107,7 @@
     },
     {
         "key": "utility/string_ref",
-        "name": "string_ref",
+        "name": "String Ref",
         "description": "String view templates.",
         "documentation": "doc/html/string_ref.html",
         "category": [


### PR DESCRIPTION
To match the pattern other boost libraries are using, the "name" field is capitalized and corresponds to what is shown on boost.org.