### PR TITLE
Use path-constant in Jamfile

### DIFF
--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -5,47 +5,10 @@
 import doxygen ;
 import quickbook ;
 
-project : requirements
-        # Path for links to Boost:
-        <xsl:param>boost.root=../../../..
-
-        # Some general style settings:
-        <xsl:param>table.footnote.number.format=1
-        <xsl:param>footnote.number.format=1
-
-        # HTML options first:
-        # Use graphics not text for navigation:
-        <xsl:param>navig.graphics=1
-        # PDF Options:
-        # TOC Generation: this is needed for FOP-0.9 and later:
-        <xsl:param>fop1.extensions=0
-        <xsl:param>xep.extensions=1
-        # TOC generation: this is needed for FOP 0.2, but must not be set to zero for FOP-0.9!
-        <xsl:param>fop.extensions=0
-        # No indent on body text:
-        <xsl:param>body.start.indent=0pt
-        # Margin size:
-        <xsl:param>page.margin.inner=0.5in
-        # Margin size:
-        <xsl:param>page.margin.outer=0.5in
-        # Paper type = A4
-        <xsl:param>paper.type=A4
-        # Yes, we want graphics for admonishments:
-        <xsl:param>admon.graphics=1
-        # Set this one for PDF generation *only*:
-        # default pnd graphics are awful in PDF form,
-        # better use SVG's instead:
-        <format>pdf:<xsl:param>admon.graphics.extension=".svg"
-        <format>pdf:<xsl:param>"admon.graphics.path=$(boost-images)/"
-        <format>pdf:<xsl:param>"boost.url.prefix=http://www.boost.org/doc/libs/release/libs/utility/doc/html"
-;
-
-path-constant boost-images : ../../../doc/src/images ;
-
 # Generate XML doxygen reference for base_from_member component in base_from_member_reference.xml
 doxygen base_from_member_reference
   :
-    ../../../boost/utility/base_from_member.hpp
+    $(BOOST_ROOT)/boost/utility/base_from_member.hpp
   :
     <location>tmp
     <doxygen:param>ENABLE_PREPROCESSING=YES
@@ -89,7 +52,7 @@ doxygen base_from_member_reference
 # Generate XML doxygen reference for boost_binary component in boost_binary_reference.xml
 doxygen boost_binary_reference
   :
-    ../../../boost/utility/binary.hpp
+    $(BOOST_ROOT)/boost/utility/binary.hpp
   :
     <location>tmp
     <doxygen:param>ENABLE_PREPROCESSING=YES
@@ -133,8 +96,8 @@ doxygen boost_binary_reference
 # Generate XML doxygen reference for call_traits component in call_traits_reference.xml
 doxygen call_traits_reference
   :
-    ../../../boost/call_traits.hpp
-    ../../../boost/detail/call_traits.hpp
+    $(BOOST_ROOT)/boost/call_traits.hpp
+    $(BOOST_ROOT)/boost/detail/call_traits.hpp
   :
     <location>tmp
     <doxygen:param>ENABLE_PREPROCESSING=YES
@@ -178,8 +141,8 @@ doxygen call_traits_reference
 # Generate XML doxygen reference for compressed_pair component in compressed_pair_reference.xml
 doxygen compressed_pair_reference
   :
-    ../../../boost/compressed_pair.hpp
-    ../../../boost/detail/compressed_pair.hpp
+    $(BOOST_ROOT)/boost/compressed_pair.hpp
+    $(BOOST_ROOT)/boost/detail/compressed_pair.hpp
   :
     <location>tmp
     <doxygen:param>ENABLE_PREPROCESSING=YES
@@ -223,8 +186,8 @@ doxygen compressed_pair_reference
 # Generate XML doxygen reference for in_place_factory component in in_place_factory_reference.xml
 doxygen in_place_factory_reference
   :
-    ../../../boost/utility/in_place_factory.hpp
-    ../../../boost/utility/typed_in_place_factory.hpp
+    $(BOOST_ROOT)/boost/utility/in_place_factory.hpp
+    $(BOOST_ROOT)/boost/utility/typed_in_place_factory.hpp
   :
     <location>tmp
     <doxygen:param>ENABLE_PREPROCESSING=YES
@@ -271,7 +234,7 @@ doxygen in_place_factory_reference
 # Generate XML doxygen reference for result_of component in result_of_reference.xml
 doxygen result_of_reference
   :
-    ../../../boost/utility/result_of.hpp
+    $(BOOST_ROOT)/boost/utility/result_of.hpp
   :
     <location>tmp
     <doxygen:param>ENABLE_PREPROCESSING=YES
@@ -315,7 +278,7 @@ doxygen result_of_reference
 # Generate XML doxygen reference for string_view component in string_view_reference.xml
 doxygen string_view_reference
   :
-    ../../../boost/utility/string_view.hpp
+    $(BOOST_ROOT)/boost/utility/string_view.hpp
   :
     <location>tmp
     <doxygen:param>ENABLE_PREPROCESSING=YES
@@ -359,7 +322,7 @@ doxygen string_view_reference
 # Generate XML doxygen reference for value_init component in value_init_reference.xml
 doxygen value_init_reference
   :
-    ../../../boost/utility/value_init.hpp
+    $(BOOST_ROOT)/boost/utility/value_init.hpp
   :
     <location>tmp
     <doxygen:param>ENABLE_PREPROCESSING=YES
@@ -405,7 +368,7 @@ xml main : main.qbk ;
 
 # Generate ./html documentation from main.xml boostbook documentation
 # Each doxygen reference in quickbook files with [xinclude tmp/<component>_reference.xml] becomes:
-# <xi:include href="../../../../libs/utility/doc/tmp/<component>_reference.xml"/>
+# <xi:include href="$(BOOST_ROOT)/libs/utility/doc/tmp/<component>_reference.xml"/>
 # in boostbook.
 # All of these <xi:include> commands give the reference the id "utility.reference"
 boostbook standalone_main
@@ -422,7 +385,7 @@ boostbook standalone_main
         <dependency>value_init_reference
         # File name of HTML output:
         # <xsl:param>root.filename=main
-        <xsl:param>boost.root=../../../..
+        <xsl:param>boost.root=$(BOOST_ROOT)
         <format>pdf:<xsl:param>"boost.url.prefix=http://www.boost.org/doc/libs/release/libs/utility/doc/html"
         # How far down we chunk nested sections: no more than two so utility component pages include their reference
         <xsl:param>chunk.section.depth=2 # 8


### PR DESCRIPTION
The previous jamfile was counting on the git layout instead of the boost release layout. We can replicate the error with `b2 libs/utility/doc` from `<boost root>`, which still tries to generate the doc in `<boost root>/libs/utility/doc/html` and `<boost root>/bin.v2/libs/utility/doc/html` still keeps temporary files, but it fails to find the links.

According to Peter, we should use path-constant instead of hardcoding relative paths in the jamfile. The reason is relative paths are often but not always relative to the Jamfile location. This PR uses [BOOST_ROOT](https://github.com/boostorg/boost/blob/bd78d4d549b43fda7c49a8536f2ec73b34e9f811/Jamroot#L146) from Jamroot. `b2 libs/utility`/`b2 libs/utility/doc` work from `<boost root>` now (locally).

What's funny is `b2 libs/core/doc` works with both layouts and boost.utility uses almost the same commands script. 