### PR TITLE
refactor: use core/swap over deprecated swap header

### DIFF
--- a/include/boost/utility/value_init.hpp
+++ b/include/boost/utility/value_init.hpp
@@ -23,7 +23,7 @@
 // contains. More details on these issues are at libs/utility/value_init.htm
 
 #include <boost/config.hpp> // For BOOST_NO_COMPLETE_VALUE_INITIALIZATION.
-#include <boost/swap.hpp>
+#include <boost/core/swap.hpp>
 #include <cstring>
 #include <cstddef>
 


### PR DESCRIPTION
In boost/swap.hpp:
```cpp
#ifndef BOOST_SWAP_HPP
#define BOOST_SWAP_HPP

// The header file at this path is deprecated;
// use boost/core/swap.hpp instead.

#include <boost/core/swap.hpp>

#endif

```