### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/utility

--- a/build.jam
+++ b/build.jam
@@ -7,13 +7,13 @@ import project ;
 
 project /boost/utility
     : common-requirements
-        <source>/boost/assert//boost_assert
-        <source>/boost/config//boost_config
-        <source>/boost/core//boost_core
-        <source>/boost/io//boost_io
-        <source>/boost/preprocessor//boost_preprocessor
-        <source>/boost/throw_exception//boost_throw_exception
-        <source>/boost/type_traits//boost_type_traits
+        <library>/boost/assert//boost_assert
+        <library>/boost/config//boost_config
+        <library>/boost/core//boost_core
+        <library>/boost/io//boost_io
+        <library>/boost/preprocessor//boost_preprocessor
+        <library>/boost/throw_exception//boost_throw_exception
+        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -5,22 +5,25 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/assert//boost_assert
+    /boost/config//boost_config
+    /boost/core//boost_core
+    /boost/io//boost_io
+    /boost/preprocessor//boost_preprocessor
+    /boost/throw_exception//boost_throw_exception
+    /boost/type_traits//boost_type_traits ;
+
 project /boost/utility
     : common-requirements
-        <library>/boost/assert//boost_assert
-        <library>/boost/config//boost_config
-        <library>/boost/core//boost_core
-        <library>/boost/io//boost_io
-        <library>/boost/preprocessor//boost_preprocessor
-        <library>/boost/throw_exception//boost_throw_exception
-        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 
 explicit
-    [ alias boost_utility ]
+    [ alias boost_utility : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_utility test ]
     ;
 
 call-if : boost-library utility
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,26 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/utility
+    : common-requirements
+        <source>/boost/assert//boost_assert
+        <source>/boost/config//boost_config
+        <source>/boost/core//boost_core
+        <source>/boost/io//boost_io
+        <source>/boost/preprocessor//boost_preprocessor
+        <source>/boost/throw_exception//boost_throw_exception
+        <source>/boost/type_traits//boost_type_traits
+        <include>include
+    ;
+
+explicit
+    [ alias boost_utility ]
+    [ alias all : boost_utility test ]
+    ;
+
+call-if : boost-library utility
+    ;

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/utility
     : common-requirements

--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -8,7 +8,7 @@ import quickbook ;
 
 project boost/libs/utility/doc ;
 
-path-constant INCLUDES : ../../.. ;
+path-constant INCLUDES : ../include ;
 path-constant boost-images : ../../../doc/src/images ;
 
 # Generate XML doxygen reference for base_from_member component in base_from_member_reference.xml

--- a/identity_type/doc/Jamfile.v2
+++ b/identity_type/doc/Jamfile.v2
@@ -8,7 +8,7 @@
 import quickbook ;
 using boostbook ;
 
-doxygen reference : ../../../../boost/utility/identity_type.hpp
+doxygen reference : ../../include/boost/utility/identity_type.hpp
     :   <reftitle>"Reference"
         <doxygen:param>PREDEFINED="DOXYGEN"
         <doxygen:param>QUIET=YES

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -13,7 +13,7 @@ run base_from_member_ref_test.cpp ;
 
 run binary_test.cpp ;
 
-run call_traits_test.cpp : -u : : <source>/boost/type_traits//testing ;
+run call_traits_test.cpp : -u : : <library>/boost/type_traits//testing ;
 
 run compressed_pair_test.cpp ;
 run compressed_pair_final_test.cpp ;
@@ -31,7 +31,7 @@ run string_ref_test2.cpp ;
 run string_ref_test_io.cpp ;
 # compile-fail string_view_from_rvalue.cpp ;
 compile string_view_constexpr_test1.cpp ;
-run string_view_test1.cpp : : : <source>/boost/container_hash//boost_container_hash ;
+run string_view_test1.cpp : : : <library>/boost/container_hash//boost_container_hash ;
 run string_view_test2.cpp ;
 run string_view_test_io.cpp ;
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -8,6 +8,8 @@
 # bring in rules for testing
 import testing ;
 
+project : requirements <library>/boost/utility//boost_utility ;
+
 run base_from_member_test.cpp ;
 run base_from_member_ref_test.cpp ;
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -13,7 +13,7 @@ run base_from_member_ref_test.cpp ;
 
 run binary_test.cpp ;
 
-run call_traits_test.cpp : -u ;
+run call_traits_test.cpp : -u : : <source>/boost/type_traits//testing ;
 
 run compressed_pair_test.cpp ;
 run compressed_pair_final_test.cpp ;
@@ -31,7 +31,7 @@ run string_ref_test2.cpp ;
 run string_ref_test_io.cpp ;
 # compile-fail string_view_from_rvalue.cpp ;
 compile string_view_constexpr_test1.cpp ;
-run string_view_test1.cpp ;
+run string_view_test1.cpp : : : <source>/boost/container_hash//boost_container_hash ;
 run string_view_test2.cpp ;
 run string_view_test_io.cpp ;
 

--- a/test/call_traits_test.cpp
+++ b/test/call_traits_test.cpp
@@ -19,8 +19,7 @@
 #include <boost/call_traits.hpp>
 
 // type_traits/test utilities
-#include <test.hpp>
-#include <check_type.hpp>
+#include "check_type.hpp"
 
 #ifdef BOOST_MSVC
 #pragma warning(disable:4181) // : warning C4181: qualifier applied to reference type; ignored

--- a/test/call_traits_test.cpp
+++ b/test/call_traits_test.cpp
@@ -18,8 +18,9 @@
 #include <typeinfo>
 #include <boost/call_traits.hpp>
 
-#include <libs/type_traits/test/test.hpp>
-#include <libs/type_traits/test/check_type.hpp>
+// type_traits/test utilities
+#include <test.hpp>
+#include <check_type.hpp>
 
 #ifdef BOOST_MSVC
 #pragma warning(disable:4181) // : warning C4181: qualifier applied to reference type; ignored


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854
- https://github.com/boostorg/type_traits/pull/195

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.